### PR TITLE
Added JSON message schema

### DIFF
--- a/internal/services/canary_message.go
+++ b/internal/services/canary_message.go
@@ -6,13 +6,27 @@
 // Package services defines an interface for canary services and related implementations
 package services
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // CanaryMessage defines the payload of a canary message
 type CanaryMessage struct {
 	ProducerID string `json:"producerId"`
 	MessageID  int    `json:"messageId"`
 	Timestamp  int64  `json:"timestamp"`
+}
+
+func NewCanaryMessage(bytes []byte) CanaryMessage {
+	var cm CanaryMessage
+	json.Unmarshal(bytes, &cm)
+	return cm
+}
+
+func (cm CanaryMessage) Json() string {
+	json, _ := json.Marshal(cm)
+	return string(json)
 }
 
 func (cm CanaryMessage) String() string {

--- a/internal/services/canary_message.go
+++ b/internal/services/canary_message.go
@@ -1,0 +1,21 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package services defines an interface for canary services and related implementations
+package services
+
+import "fmt"
+
+// CanaryMessage defines the payload of a canary message
+type CanaryMessage struct {
+	ProducerID string `json:"producerId"`
+	MessageID  int    `json:"messageId"`
+	Timestamp  int64  `json:"timestamp"`
+}
+
+func (cm CanaryMessage) String() string {
+	return fmt.Sprintf("{ProducerID:%s, MessageID:%d, Timestamp:%d}",
+		cm.ProducerID, cm.MessageID, cm.Timestamp)
+}

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -8,6 +8,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 
@@ -71,8 +72,15 @@ func (cgh *consumerGroupHandler) Cleanup(sarama.ConsumerGroupSession) error {
 
 func (cgh *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
-		log.Printf("Message received: value=%s, partition=%d, offset=%d", string(message.Value), message.Partition, message.Offset)
+		cm := jsonToCanaryMessage(message.Value)
+		log.Printf("Message received: value=%+v, partition=%d, offset=%d", cm, message.Partition, message.Offset)
 		session.MarkMessage(message, "")
 	}
 	return nil
+}
+
+func jsonToCanaryMessage(value []byte) CanaryMessage {
+	var cm CanaryMessage
+	json.Unmarshal(value, &cm)
+	return cm
 }

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -8,7 +8,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"os"
 
@@ -72,15 +71,9 @@ func (cgh *consumerGroupHandler) Cleanup(sarama.ConsumerGroupSession) error {
 
 func (cgh *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
-		cm := jsonToCanaryMessage(message.Value)
+		cm := NewCanaryMessage(message.Value)
 		log.Printf("Message received: value=%+v, partition=%d, offset=%d", cm, message.Partition, message.Offset)
 		session.MarkMessage(message, "")
 	}
 	return nil
-}
-
-func jsonToCanaryMessage(value []byte) CanaryMessage {
-	var cm CanaryMessage
-	json.Unmarshal(value, &cm)
-	return cm
 }

--- a/internal/services/producer.go
+++ b/internal/services/producer.go
@@ -7,7 +7,6 @@
 package services
 
 import (
-	"encoding/json"
 	"log"
 	"os"
 	"time"
@@ -40,9 +39,7 @@ func (p *Producer) Start() {
 	log.Printf("Starting producer")
 	go func() {
 		for {
-			timestamp := time.Now().UnixNano() / 1000000 // timestamp in milliseconds
-			p.index++
-			cmJSON := canaryMessageValueToJson(p.config.ProducerClientID, p.index, timestamp)
+			cmJSON := p.newCanaryMessage().Json()
 			msg := &sarama.ProducerMessage{
 				Topic: p.config.Topic,
 				Value: sarama.StringEncoder(cmJSON),
@@ -69,12 +66,13 @@ func (p *Producer) Stop() {
 	log.Printf("Producer closed")
 }
 
-func canaryMessageValueToJson(producerID string, index int, timestamp int64) string {
-	m := CanaryMessage{
-		ProducerID: producerID,
-		MessageID:  index,
+func (p *Producer) newCanaryMessage() CanaryMessage {
+	p.index++
+	timestamp := time.Now().UnixNano() / 1000000 // timestamp in milliseconds
+	cm := CanaryMessage{
+		ProducerID: p.config.ProducerClientID,
+		MessageID:  p.index,
 		Timestamp:  timestamp,
 	}
-	json, _ := json.Marshal(m)
-	return string(json)
+	return cm
 }


### PR DESCRIPTION
This trivial PR added the JSOM message schema as defined by the proposal instead of the current fixed "payload".
It doesn't add the proper message index yet that could be different for each partition.
This will be done in future PR.