### PR TITLE
Added Dockerfile and Makefile to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:7
+
+ARG version
+ENV VERSION=${version}
+
+ADD target/main /
+
+CMD ["/main"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+IMAGE ?= strimzi-canary
+VERSION ?= latest
+TAG ?= latest
+
+
+.PHONY: help dobuild build tag push all
+
+help:
+	@echo "Makefile arguments:"
+	@echo "REGISTRY: Image registry"
+	@echo "ORG: Image organisation"
+	@echo "Makefile commands:"
+	@echo "build"
+	@echo "tag"
+	@echo "push"
+	@echo "all"
+
+.DEFAULT_GOAL := all
+
+gobuild:
+	go build -o target/main ./cmd
+
+build:
+	@docker	build --pull --build-arg version=$(VERSION) -t ${IMAGE}:${VERSION} .
+
+tag:
+	@echo "Tagging  image ${IMAGE}:${VERSION} ${REGISTRY}/${ORG}/${IMAGE}:${TAG}"
+	@docker tag ${IMAGE}:${VERSION} ${REGISTRY}/${ORG}/${IMAGE}:${TAG}
+
+push:
+	@docker push ${REGISTRY}/${ORG}/${IMAGE}:${TAG}
+
+all: build tag push


### PR DESCRIPTION
Dockerfile and Makefile added to allow building and pushing the image. Makefile includes `build`, `tag` and `push` targets.

However as there has not been an initial release of the Strimzi Canary yet there are no default values for the image registry and organisation in Makefile. They must be specified as arguments in order to tag and push the image. 

Addresses #10 