### PR TITLE
Fix replica assignment invalid

### DIFF
--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/strimzi/strimzi-canary/internal/config"
@@ -144,11 +145,18 @@ func (ts *TopicService) alterTopic(currentPartitions int, brokersNumber int) (ma
 	var err error
 	// less partitions than brokers (scale up)
 	if currentPartitions < brokersNumber {
-		// passing the assigments just for the partitions that needs to be created
-		err = ts.admin.CreatePartitions(ts.canaryConfig.Topic, int32(brokersNumber), ass[currentPartitions:], false)
+		// when replication factor is less than 3 because brokers are not 3 yet (see replicationFactor := min(brokersNumber, 3)),
+		// it's not possible to create the new partitions directly with a replication factor higher than the current ones.
+		// So first alter the assignment of current partitions with new replicas (higher replication factor)
+		// fixes: https://github.com/strimzi/strimzi-canary/issues/16
+		err = ts.alterAssignments(ts.canaryConfig.Topic, ass[:currentPartitions])
+		if err == nil {
+			// passing the assigments just for the partitions that needs to be created
+			err = ts.admin.CreatePartitions(ts.canaryConfig.Topic, int32(brokersNumber), ass[currentPartitions:], false)
+		}
 	} else {
 		// more or equals partitions than brokers, just need reassignment
-		err = ts.admin.AlterPartitionReassignments(ts.canaryConfig.Topic, ass)
+		err = ts.alterAssignments(ts.canaryConfig.Topic, ass[:currentPartitions])
 	}
 	return assignments, err
 }
@@ -181,6 +189,36 @@ func (ts *TopicService) assignments(currentPartitions int, brokersNumber int) (m
 	}
 	log.Printf("assignments = %v, minISR = %d", assignments, int(minISR))
 	return assignments, int(minISR)
+}
+
+func (ts *TopicService) alterAssignments(topic string, assignments [][]int32) error {
+	err := ts.admin.AlterPartitionReassignments(topic, assignments)
+	if err != nil {
+		return err
+	}
+
+	partitions := make([]int32, 0, len(assignments))
+	for k := range assignments {
+		partitions = append(partitions, int32(k))
+	}
+	// loop for checking that there is no ongoing reassignments
+	for {
+		ongoing := false
+		reassignments, err := ts.admin.ListPartitionReassignments(topic, partitions)
+		if err != nil {
+			return nil
+		}
+		// on each partition of the topic shouldn't be adding or removing replicas ongoing
+		for _, v := range reassignments[topic] {
+			log.Printf("List reassignments = %+v\n", v)
+			ongoing = ongoing || (len(v.AddingReplicas) != 0 || len(v.RemovingReplicas) != 0)
+		}
+		if !ongoing {
+			break
+		}
+		time.Sleep(2000 * time.Millisecond)
+	}
+	return nil
 }
 
 func max(x, y int) int {


### PR DESCRIPTION
This PR fixes #16.
As described in the committed code, this happens in the following scenario.

When the replication factor is less than 3 because brokers are not 3 yet (see `replicationFactor := min(brokersNumber, 3)`),
it's not possible to create the new partitions directly with a replication factor higher than the current ones.
So first alter the assignment of current partitions with new replicas (higher replication factor).
It's not needed anymore when brokers are 3 or more because the replication factor (as 3 max) cannot be higher than that.

The PR does what described even checking that there is no ongoing reassignment ongoing before doing the new partition creation.