### PR TITLE
Added backoff for consumer retrying to join consumer group

### DIFF
--- a/internal/services/backoff.go
+++ b/internal/services/backoff.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	ScaleDefault       = 200
-	BaseDefault        = 2
 	MaxAttemptsDefault = 6
 )
 
@@ -21,7 +20,6 @@ const (
 type Backoff struct {
 	maxAttempts int
 	scale       int64
-	base        int
 	attempt     int
 }
 
@@ -33,11 +31,10 @@ func (e *MaxAttemptsExceeded) Error() string {
 }
 
 // NewBackoff returns an instance of a Backoff struct
-func NewBackoff(maxAttempts int, scale int64, base int) *Backoff {
+func NewBackoff(maxAttempts int, scale int64) *Backoff {
 	backoff := Backoff{
 		maxAttempts: maxAttempts,
 		scale:       scale,
-		base:        base,
 		attempt:     0,
 	}
 	return &backoff
@@ -49,26 +46,7 @@ func (b *Backoff) Delay() (time.Duration, error) {
 	if b.attempt == b.maxAttempts {
 		return 0, &MaxAttemptsExceeded{}
 	}
+	delay := time.Duration(b.scale * 1 << b.attempt)
 	b.attempt++
-	return time.Duration(b.delay(b.attempt)), nil
-}
-
-func (b *Backoff) delay(n int) int64 {
-	if n == 0 {
-		return 0
-	}
-	pow := 1
-	/*
-		for {
-			n--
-			if n <= 1 {
-				break
-			}
-			pow *= b.base
-		}
-	*/
-	for ; n > 1; n-- {
-		pow *= b.base
-	}
-	return b.scale * int64(pow)
+	return delay, nil
 }

--- a/internal/services/backoff.go
+++ b/internal/services/backoff.go
@@ -1,0 +1,74 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package services defines an interface for canary services and related implementations
+package services
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	ScaleDefault       = 200
+	BaseDefault        = 2
+	MaxAttemptsDefault = 6
+)
+
+// Backoff encapsulates computing delays for an exponential back-off, when an operation has to be retried
+type Backoff struct {
+	maxAttempts int
+	scale       int64
+	base        int
+	attempt     int
+}
+
+// MaxAttemptsExceeded defines the error for the max attempts exceeded
+type MaxAttemptsExceeded struct{}
+
+func (e *MaxAttemptsExceeded) Error() string {
+	return fmt.Sprintf("Maximum number of attempts exceeded")
+}
+
+// NewBackoff returns an instance of a Backoff struct
+func NewBackoff(maxAttempts int, scale int64, base int) *Backoff {
+	backoff := Backoff{
+		maxAttempts: maxAttempts,
+		scale:       scale,
+		base:        base,
+		attempt:     0,
+	}
+	return &backoff
+}
+
+// Delay computes a delay in milliseconds based on the current Backoff instance configuration
+// Returns the delay in milliseconds and an error if the max attempts is reached, otherwise it's nil
+func (b *Backoff) Delay() (time.Duration, error) {
+	if b.attempt == b.maxAttempts {
+		return 0, &MaxAttemptsExceeded{}
+	}
+	b.attempt++
+	return time.Duration(b.delay(b.attempt)), nil
+}
+
+func (b *Backoff) delay(n int) int64 {
+	if n == 0 {
+		return 0
+	}
+	pow := 1
+	/*
+		for {
+			n--
+			if n <= 1 {
+				break
+			}
+			pow *= b.base
+		}
+	*/
+	for ; n > 1; n-- {
+		pow *= b.base
+	}
+	return b.scale * int64(pow)
+}

--- a/internal/services/backoff_test.go
+++ b/internal/services/backoff_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBackoffDelayDefault(t *testing.T) {
-	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, BaseDefault)
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault)
 	want := time.Duration(200)
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
@@ -20,7 +20,7 @@ func TestBackoffDelayDefault(t *testing.T) {
 }
 
 func TestBackoffMoreDelayDefault(t *testing.T) {
-	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, BaseDefault)
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault)
 	want := time.Duration(200)
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
@@ -37,7 +37,7 @@ func TestBackoffMoreDelayDefault(t *testing.T) {
 
 func TestBackoffMaxAttemptsExceeded(t *testing.T) {
 	maxAttempts := 3
-	b := NewBackoff(maxAttempts, ScaleDefault, BaseDefault)
+	b := NewBackoff(maxAttempts, ScaleDefault)
 
 	for i := 0; i < maxAttempts; i++ {
 		if _, err := b.Delay(); err != nil {
@@ -51,7 +51,7 @@ func TestBackoffMaxAttemptsExceeded(t *testing.T) {
 }
 
 func TestBackoffMoreDelay(t *testing.T) {
-	b := NewBackoff(3, 5000, BaseDefault)
+	b := NewBackoff(3, 5000)
 	want := time.Duration(5000)
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)

--- a/internal/services/backoff_test.go
+++ b/internal/services/backoff_test.go
@@ -1,0 +1,67 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package services defines an interface for canary services and related implementations
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoffDelayDefault(t *testing.T) {
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, BaseDefault)
+	want := time.Duration(200)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+}
+
+func TestBackoffMoreDelayDefault(t *testing.T) {
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, BaseDefault)
+	want := time.Duration(200)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+	want = time.Duration(400)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+	want = time.Duration(800)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+}
+
+func TestBackoffMaxAttemptsExceeded(t *testing.T) {
+	maxAttempts := 3
+	b := NewBackoff(maxAttempts, ScaleDefault, BaseDefault)
+
+	for i := 0; i < maxAttempts; i++ {
+		if _, err := b.Delay(); err != nil {
+			t.Errorf("Error should be nil, got = %v", err)
+			return
+		}
+	}
+	if _, err := b.Delay(); err == nil {
+		t.Errorf("Expecting max attempts exceeded error")
+	}
+}
+
+func TestBackoffMoreDelay(t *testing.T) {
+	b := NewBackoff(3, 5000, BaseDefault)
+	want := time.Duration(5000)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+	want = time.Duration(10000)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+	want = time.Duration(20000)
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+}

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -83,7 +83,7 @@ func NewConsumerService(canaryConfig *config.CanaryConfig, client sarama.Client)
 // It can be exited cancelling the corresponding context through the cancel function provided by the ConsumerService instance
 // Before returning, it waits for the consumer to join the group for all the partitions provided with numPartitions parameter
 func (cs *ConsumerService) Consume(numPartitions int) {
-	backoff := NewBackoff(maxConsumeAttempts, 5000, BaseDefault)
+	backoff := NewBackoff(maxConsumeAttempts, 5000)
 	for {
 		cgh := &consumerGroupHandler{
 			consumerService: cs,


### PR DESCRIPTION
This PR fixes #23 
It adds a backoff mechanism for the consumer to delay and retry on joining a consumer group when it times out.