### PR TITLE
Adding retrying mechanims to connect Kafka cluster on startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,7 @@ func newClient(canaryConfig *config.CanaryConfig) sarama.Client {
 	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
-	backoff := services.NewBackoff(canaryConfig.BootstrapMaxAttempts, 5000)
+	backoff := services.NewBackoff(canaryConfig.BootstrapBackoffMaxAttempts, int64(canaryConfig.BootstrapBackoffScale))
 	for {
 		client, clientErr := sarama.NewClient([]string{canaryConfig.BootstrapServers}, config)
 		if clientErr == nil {
@@ -65,7 +65,7 @@ func newClient(canaryConfig *config.CanaryConfig) sarama.Client {
 		}
 		delay, backoffErr := backoff.Delay()
 		if backoffErr != nil {
-			log.Printf("Error connecting to the Kafka cluster after %d retries: %v", canaryConfig.BootstrapMaxAttempts, backoffErr)
+			log.Printf("Error connecting to the Kafka cluster after %d retries: %v", canaryConfig.BootstrapBackoffMaxAttempts, backoffErr)
 			os.Exit(1)
 		}
 		log.Printf("Error creating new Sarama client, retrying in %d ms: %v", delay, clientErr)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,7 @@ func newClient(canaryConfig *config.CanaryConfig) sarama.Client {
 	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
-	backoff := services.NewBackoff(canaryConfig.BootstrapBackoffMaxAttempts, int64(canaryConfig.BootstrapBackoffScale))
+	backoff := services.NewBackoff(canaryConfig.BootstrapBackoffMaxAttempts, canaryConfig.BootstrapBackoffScale*time.Millisecond, services.MaxDefault)
 	for {
 		client, clientErr := sarama.NewClient([]string{canaryConfig.BootstrapServers}, config)
 		if clientErr == nil {
@@ -68,7 +68,7 @@ func newClient(canaryConfig *config.CanaryConfig) sarama.Client {
 			log.Printf("Error connecting to the Kafka cluster after %d retries: %v", canaryConfig.BootstrapBackoffMaxAttempts, backoffErr)
 			os.Exit(1)
 		}
-		log.Printf("Error creating new Sarama client, retrying in %d ms: %v", delay, clientErr)
-		time.Sleep(delay * time.Millisecond)
+		log.Printf("Error creating new Sarama client, retrying in %d ms: %v", delay.Milliseconds(), clientErr)
+		time.Sleep(delay)
 	}
 }

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -16,57 +16,61 @@ import (
 
 const (
 	// environment variables declaration
-	BootstrapServersEnvVar       = "KAFKA_BOOTSTRAP_SERVERS"
-	BootstrapMaxAttemptsEnvVar   = "KAFKA_BOOTSTRAP_MAX_ATTEMPTS"
-	TopicEnvVar                  = "TOPIC"
-	ReconcileIntervalEnvVar      = "RECONCILE_INTERVAL_MS"
-	ClientIDEnvVar               = "CLIENT_ID"
-	ConsumerGroupIDEnvVar        = "CONSUMER_GROUP_ID"
-	TLSEnabledEnvVar             = "TLS_ENABLED"
-	ProducerLatencyBucketsEnvVar = "PRODUCER_LATENCY_BUCKETS"
-	EndToEndLatencyBucketsEnvVar = "ENDTOEND_LATENCY_BUCKETS"
-	ExpectedClusterSizeEnvVar    = "EXPECTED_CLUSTER_SIZE"
+	BootstrapServersEnvVar            = "KAFKA_BOOTSTRAP_SERVERS"
+	BootstrapBackoffMaxAttemptsEnvVar = "KAFKA_BOOTSTRAP_BACKOFF_MAX_ATTEMPTS"
+	BootstrapBackoffScaleEnvVar       = "KAFKA_BOOTSTRAP_BACKOFF_SCALE"
+	TopicEnvVar                       = "TOPIC"
+	ReconcileIntervalEnvVar           = "RECONCILE_INTERVAL_MS"
+	ClientIDEnvVar                    = "CLIENT_ID"
+	ConsumerGroupIDEnvVar             = "CONSUMER_GROUP_ID"
+	TLSEnabledEnvVar                  = "TLS_ENABLED"
+	ProducerLatencyBucketsEnvVar      = "PRODUCER_LATENCY_BUCKETS"
+	EndToEndLatencyBucketsEnvVar      = "ENDTOEND_LATENCY_BUCKETS"
+	ExpectedClusterSizeEnvVar         = "EXPECTED_CLUSTER_SIZE"
 
 	// default values for environment variables
-	BootstrapServersDefault       = "localhost:9092"
-	BootstrapMaxAttemptsDefault   = 10
-	TopicDefault                  = "__strimzi_canary"
-	ReconcileIntervalDefault      = 30000
-	ClientIDDefault               = "strimzi-canary-client"
-	ConsumerGroupIDDefault        = "strimzi-canary-group"
-	TLSEnabledDefault             = false
-	ProducerLatencyBucketsDefault = "100,200,400,800,1600"
-	EndToEndLatencyBucketsDefault = "100,200,400,800,1600"
-	ExpectedClusterSizeDefault    = -1 // "dynamic" reassignment is enabled
+	BootstrapServersDefault            = "localhost:9092"
+	BootstrapBackoffMaxAttemptsDefault = 10
+	BootstrapBackoffScaleDefault       = 5000
+	TopicDefault                       = "__strimzi_canary"
+	ReconcileIntervalDefault           = 30000
+	ClientIDDefault                    = "strimzi-canary-client"
+	ConsumerGroupIDDefault             = "strimzi-canary-group"
+	TLSEnabledDefault                  = false
+	ProducerLatencyBucketsDefault      = "100,200,400,800,1600"
+	EndToEndLatencyBucketsDefault      = "100,200,400,800,1600"
+	ExpectedClusterSizeDefault         = -1 // "dynamic" reassignment is enabled
 )
 
 // CanaryConfig defines the canary tool configuration
 type CanaryConfig struct {
-	BootstrapServers       string
-	BootstrapMaxAttempts   int
-	Topic                  string
-	ReconcileInterval      time.Duration
-	ClientID               string
-	ConsumerGroupID        string
-	TLSEnabled             bool
-	ProducerLatencyBuckets []float64
-	EndToEndLatencyBuckets []float64
-	ExpectedClusterSize    int
+	BootstrapServers            string
+	BootstrapBackoffMaxAttempts int
+	BootstrapBackoffScale       int
+	Topic                       string
+	ReconcileInterval           time.Duration
+	ClientID                    string
+	ConsumerGroupID             string
+	TLSEnabled                  bool
+	ProducerLatencyBuckets      []float64
+	EndToEndLatencyBuckets      []float64
+	ExpectedClusterSize         int
 }
 
 // NewCanaryConfig returns an configuration instance from environment variables
 func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
-		BootstrapServers:       lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
-		BootstrapMaxAttempts:   lookupIntEnv(BootstrapMaxAttemptsEnvVar, BootstrapMaxAttemptsDefault),
-		Topic:                  lookupStringEnv(TopicEnvVar, TopicDefault),
-		ReconcileInterval:      time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
-		ClientID:               lookupStringEnv(ClientIDEnvVar, ClientIDDefault),
-		ConsumerGroupID:        lookupStringEnv(ConsumerGroupIDEnvVar, ConsumerGroupIDDefault),
-		TLSEnabled:             lookupBoolEnv(TLSEnabledEnvVar, TLSEnabledDefault),
-		ProducerLatencyBuckets: latencyBuckets(lookupStringEnv(ProducerLatencyBucketsEnvVar, ProducerLatencyBucketsDefault)),
-		EndToEndLatencyBuckets: latencyBuckets(lookupStringEnv(EndToEndLatencyBucketsEnvVar, EndToEndLatencyBucketsDefault)),
-		ExpectedClusterSize:    lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
+		BootstrapServers:            lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
+		BootstrapBackoffMaxAttempts: lookupIntEnv(BootstrapBackoffMaxAttemptsEnvVar, BootstrapBackoffMaxAttemptsDefault),
+		BootstrapBackoffScale:       lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault),
+		Topic:                       lookupStringEnv(TopicEnvVar, TopicDefault),
+		ReconcileInterval:           time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
+		ClientID:                    lookupStringEnv(ClientIDEnvVar, ClientIDDefault),
+		ConsumerGroupID:             lookupStringEnv(ConsumerGroupIDEnvVar, ConsumerGroupIDDefault),
+		TLSEnabled:                  lookupBoolEnv(TLSEnabledEnvVar, TLSEnabledDefault),
+		ProducerLatencyBuckets:      latencyBuckets(lookupStringEnv(ProducerLatencyBucketsEnvVar, ProducerLatencyBucketsDefault)),
+		EndToEndLatencyBuckets:      latencyBuckets(lookupStringEnv(EndToEndLatencyBucketsEnvVar, EndToEndLatencyBucketsDefault)),
+		ExpectedClusterSize:         lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
 	}
 	return &config
 }
@@ -111,8 +115,8 @@ func latencyBuckets(bucketsConfig string) []float64 {
 }
 
 func (c CanaryConfig) String() string {
-	return fmt.Sprintf("{BootstrapServers:%s, BootstrapMaxAttempts:%d, Topic:%s, ReconcileInterval:%d ms, ClientID:%s, "+
-		"ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d}",
-		c.BootstrapServers, c.BootstrapMaxAttempts, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
+	return fmt.Sprintf("{BootstrapServers:%s, BootstrapBackoffMaxAttempts:%d, BootstrapBackoffScale:%d, Topic:%s, ReconcileInterval:%d ms, "+
+		"ClientID:%s, ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d}",
+		c.BootstrapServers, c.BootstrapBackoffMaxAttempts, c.BootstrapBackoffScale, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
 		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize)
 }

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -17,6 +17,7 @@ import (
 const (
 	// environment variables declaration
 	BootstrapServersEnvVar       = "KAFKA_BOOTSTRAP_SERVERS"
+	BootstrapMaxAttemptsEnvVar   = "KAFKA_BOOTSTRAP_MAX_ATTEMPTS"
 	TopicEnvVar                  = "TOPIC"
 	ReconcileIntervalEnvVar      = "RECONCILE_INTERVAL_MS"
 	ClientIDEnvVar               = "CLIENT_ID"
@@ -28,6 +29,7 @@ const (
 
 	// default values for environment variables
 	BootstrapServersDefault       = "localhost:9092"
+	BootstrapMaxAttemptsDefault   = 10
 	TopicDefault                  = "__strimzi_canary"
 	ReconcileIntervalDefault      = 30000
 	ClientIDDefault               = "strimzi-canary-client"
@@ -41,6 +43,7 @@ const (
 // CanaryConfig defines the canary tool configuration
 type CanaryConfig struct {
 	BootstrapServers       string
+	BootstrapMaxAttempts   int
 	Topic                  string
 	ReconcileInterval      time.Duration
 	ClientID               string
@@ -55,6 +58,7 @@ type CanaryConfig struct {
 func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
 		BootstrapServers:       lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
+		BootstrapMaxAttempts:   lookupIntEnv(BootstrapMaxAttemptsEnvVar, BootstrapMaxAttemptsDefault),
 		Topic:                  lookupStringEnv(TopicEnvVar, TopicDefault),
 		ReconcileInterval:      time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
 		ClientID:               lookupStringEnv(ClientIDEnvVar, ClientIDDefault),
@@ -107,8 +111,8 @@ func latencyBuckets(bucketsConfig string) []float64 {
 }
 
 func (c CanaryConfig) String() string {
-	return fmt.Sprintf("{BootstrapServers:%s, Topic:%s, ReconcileInterval:%d ms, ClientID:%s, "+
+	return fmt.Sprintf("{BootstrapServers:%s, BootstrapMaxAttempts:%d, Topic:%s, ReconcileInterval:%d ms, ClientID:%s, "+
 		"ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d}",
-		c.BootstrapServers, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
+		c.BootstrapServers, c.BootstrapMaxAttempts, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
 		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize)
 }

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -46,7 +46,7 @@ const (
 type CanaryConfig struct {
 	BootstrapServers            string
 	BootstrapBackoffMaxAttempts int
-	BootstrapBackoffScale       int
+	BootstrapBackoffScale       time.Duration
 	Topic                       string
 	ReconcileInterval           time.Duration
 	ClientID                    string
@@ -62,7 +62,7 @@ func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
 		BootstrapServers:            lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
 		BootstrapBackoffMaxAttempts: lookupIntEnv(BootstrapBackoffMaxAttemptsEnvVar, BootstrapBackoffMaxAttemptsDefault),
-		BootstrapBackoffScale:       lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault),
+		BootstrapBackoffScale:       time.Duration(lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault)),
 		Topic:                       lookupStringEnv(TopicEnvVar, TopicDefault),
 		ReconcileInterval:           time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
 		ClientID:                    lookupStringEnv(ClientIDEnvVar, ClientIDDefault),


### PR DESCRIPTION
This PR fixes #33 adding a retrying mechanism to connect Kafka cluster during startup to avoid just exiting if the cluster is not available yet.