### PR TITLE
Fixed the backoff with the nanoseconds Duration meaning

### DIFF
--- a/internal/services/backoff.go
+++ b/internal/services/backoff.go
@@ -12,14 +12,16 @@ import (
 )
 
 const (
-	ScaleDefault       = 200
+	ScaleDefault       = 200 * time.Millisecond
+	MaxDefault         = 5 * time.Minute
 	MaxAttemptsDefault = 6
 )
 
 // Backoff encapsulates computing delays for an exponential back-off, when an operation has to be retried
 type Backoff struct {
 	maxAttempts int
-	scale       int64
+	scale       time.Duration
+	max         time.Duration
 	attempt     int
 }
 
@@ -31,10 +33,19 @@ func (e *MaxAttemptsExceeded) Error() string {
 }
 
 // NewBackoff returns an instance of a Backoff struct
-func NewBackoff(maxAttempts int, scale int64) *Backoff {
+func NewBackoff(maxAttempts int, scale time.Duration, max time.Duration) *Backoff {
+	actualScale := scale
+	if actualScale <= 0 {
+		actualScale = ScaleDefault
+	}
+	actualMax := max
+	if actualMax <= 0 {
+		actualMax = MaxDefault
+	}
 	backoff := Backoff{
 		maxAttempts: maxAttempts,
-		scale:       scale,
+		scale:       actualScale,
+		max:         actualMax,
 		attempt:     0,
 	}
 	return &backoff
@@ -47,6 +58,9 @@ func (b *Backoff) Delay() (time.Duration, error) {
 		return 0, &MaxAttemptsExceeded{}
 	}
 	delay := time.Duration(b.scale * 1 << b.attempt)
+	if delay > b.max {
+		delay = b.max
+	}
 	b.attempt++
 	return delay, nil
 }

--- a/internal/services/backoff.go
+++ b/internal/services/backoff.go
@@ -51,8 +51,8 @@ func NewBackoff(maxAttempts int, scale time.Duration, max time.Duration) *Backof
 	return &backoff
 }
 
-// Delay computes a delay in milliseconds based on the current Backoff instance configuration
-// Returns the delay in milliseconds and an error if the max attempts is reached, otherwise it's nil
+// Delay computes a delay in terms of Duration (nanoseconds) based on the current Backoff instance configuration
+// Returns the delay in terms of Duration (nanoseconds) and an error if the max attempts is reached, otherwise it's nil
 func (b *Backoff) Delay() (time.Duration, error) {
 	if b.attempt == b.maxAttempts {
 		return 0, &MaxAttemptsExceeded{}

--- a/internal/services/backoff_test.go
+++ b/internal/services/backoff_test.go
@@ -12,24 +12,32 @@ import (
 )
 
 func TestBackoffDelayDefault(t *testing.T) {
-	b := NewBackoff(MaxAttemptsDefault, ScaleDefault)
-	want := time.Duration(200)
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, MaxDefault)
+	want := 200 * time.Millisecond
+	if delay, _ := b.Delay(); delay != want {
+		t.Errorf("Delay: got = %v, want = %v", delay, want)
+	}
+}
+
+func TestBackoffMax(t *testing.T) {
+	b := NewBackoff(MaxAttemptsDefault, 6*time.Minute, MaxDefault)
+	want := 5 * time.Minute
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
 }
 
 func TestBackoffMoreDelayDefault(t *testing.T) {
-	b := NewBackoff(MaxAttemptsDefault, ScaleDefault)
-	want := time.Duration(200)
+	b := NewBackoff(MaxAttemptsDefault, ScaleDefault, MaxDefault)
+	want := 200 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
-	want = time.Duration(400)
+	want = 400 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
-	want = time.Duration(800)
+	want = 800 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
@@ -37,7 +45,7 @@ func TestBackoffMoreDelayDefault(t *testing.T) {
 
 func TestBackoffMaxAttemptsExceeded(t *testing.T) {
 	maxAttempts := 3
-	b := NewBackoff(maxAttempts, ScaleDefault)
+	b := NewBackoff(maxAttempts, ScaleDefault, MaxDefault)
 
 	for i := 0; i < maxAttempts; i++ {
 		if _, err := b.Delay(); err != nil {
@@ -51,16 +59,16 @@ func TestBackoffMaxAttemptsExceeded(t *testing.T) {
 }
 
 func TestBackoffMoreDelay(t *testing.T) {
-	b := NewBackoff(3, 5000)
-	want := time.Duration(5000)
+	b := NewBackoff(3, 5000*time.Millisecond, MaxDefault)
+	want := 5000 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
-	want = time.Duration(10000)
+	want = 10000 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}
-	want = time.Duration(20000)
+	want = 20000 * time.Millisecond
 	if delay, _ := b.Delay(); delay != want {
 		t.Errorf("Delay: got = %v, want = %v", delay, want)
 	}

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -83,7 +83,7 @@ func NewConsumerService(canaryConfig *config.CanaryConfig, client sarama.Client)
 // It can be exited cancelling the corresponding context through the cancel function provided by the ConsumerService instance
 // Before returning, it waits for the consumer to join the group for all the partitions provided with numPartitions parameter
 func (cs *ConsumerService) Consume(numPartitions int) {
-	backoff := NewBackoff(maxConsumeAttempts, 5000)
+	backoff := NewBackoff(maxConsumeAttempts, 5000*time.Millisecond, MaxDefault)
 	for {
 		cgh := &consumerGroupHandler{
 			consumerService: cs,
@@ -119,7 +119,7 @@ func (cs *ConsumerService) Consume(numPartitions int) {
 				log.Printf("Error joining the consumer group: %v", err)
 				os.Exit(1)
 			}
-			time.Sleep(delay * time.Millisecond)
+			time.Sleep(delay)
 		} else {
 			break
 		}


### PR DESCRIPTION
The current backoff stuff relying on a misleading meaning of the delay in milliseconds.
This PR reverts everything into Duration terms which defines times in nanoseconds as expected by sleep functions as well.