### PR TITLE
Added liveness and readiness HTTP endpoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,8 +23,8 @@ func main() {
 	canaryConfig := config.NewCanaryConfig()
 	log.Printf("Starting Strimzi canary tool with config: %+v\n", canaryConfig)
 
-	metricsServer := servers.NewMetricsServer()
-	metricsServer.Start()
+	httpServer := servers.NewHttpServer()
+	httpServer.Start()
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGKILL)
@@ -43,7 +43,7 @@ func main() {
 		log.Printf("Got signal: %v\n", sig)
 	}
 	canaryManager.Stop()
-	metricsServer.Stop()
+	httpServer.Stop()
 
 	log.Printf("Strimzi canary stopped")
 }

--- a/internal/services/healthcheck.go
+++ b/internal/services/healthcheck.go
@@ -1,0 +1,21 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package services defines an interface for canary services and related implementations
+package services
+
+import "net/http"
+
+func LivenessHandler() http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("OK"))
+	})
+}
+
+func ReadinessHandler() http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("OK"))
+	})
+}


### PR DESCRIPTION
This PR fixes #27 adding healthcheck endpoints.
Nothing "complex" is done to verify the liveness and readiness of the canary, just returning "OK" for now if the HTTP server is reachable.