### PR TITLE
Making Kafka version configurable

### DIFF
--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -27,6 +27,7 @@ const (
 	ProducerLatencyBucketsEnvVar      = "PRODUCER_LATENCY_BUCKETS"
 	EndToEndLatencyBucketsEnvVar      = "ENDTOEND_LATENCY_BUCKETS"
 	ExpectedClusterSizeEnvVar         = "EXPECTED_CLUSTER_SIZE"
+	KafkaVersionEnvVar                = "KAFKA_VERSION"
 
 	// default values for environment variables
 	BootstrapServersDefault            = "localhost:9092"
@@ -40,6 +41,7 @@ const (
 	ProducerLatencyBucketsDefault      = "100,200,400,800,1600"
 	EndToEndLatencyBucketsDefault      = "100,200,400,800,1600"
 	ExpectedClusterSizeDefault         = -1 // "dynamic" reassignment is enabled
+	KafkaVersionDefault                = "2.7.0"
 )
 
 // CanaryConfig defines the canary tool configuration
@@ -55,6 +57,7 @@ type CanaryConfig struct {
 	ProducerLatencyBuckets      []float64
 	EndToEndLatencyBuckets      []float64
 	ExpectedClusterSize         int
+	KafkaVersion                string
 }
 
 // NewCanaryConfig returns an configuration instance from environment variables
@@ -71,6 +74,7 @@ func NewCanaryConfig() *CanaryConfig {
 		ProducerLatencyBuckets:      latencyBuckets(lookupStringEnv(ProducerLatencyBucketsEnvVar, ProducerLatencyBucketsDefault)),
 		EndToEndLatencyBuckets:      latencyBuckets(lookupStringEnv(EndToEndLatencyBucketsEnvVar, EndToEndLatencyBucketsDefault)),
 		ExpectedClusterSize:         lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
+		KafkaVersion:                lookupStringEnv(KafkaVersionEnvVar, KafkaVersionDefault),
 	}
 	return &config
 }
@@ -116,7 +120,7 @@ func latencyBuckets(bucketsConfig string) []float64 {
 
 func (c CanaryConfig) String() string {
 	return fmt.Sprintf("{BootstrapServers:%s, BootstrapBackoffMaxAttempts:%d, BootstrapBackoffScale:%d, Topic:%s, ReconcileInterval:%d ms, "+
-		"ClientID:%s, ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d}",
+		"ClientID:%s, ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d, KafkaVersion:%s}",
 		c.BootstrapServers, c.BootstrapBackoffMaxAttempts, c.BootstrapBackoffScale, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
-		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize)
+		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize, c.KafkaVersion)
 }


### PR DESCRIPTION
This PR fixes #12 making the Kafka version to use in the Sarama client configurable.