### PR TITLE
Make Docker repo configurable on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_REGISTRY ?= docker.io
 DOCKER_ORG ?= $(USER)
 DOCKER_TAG ?= latest
+DOCKER_REPO ?= canary
 
 BINARY ?= strimzi-canary
 
@@ -10,11 +11,11 @@ go_build:
 
 docker_build:
 	echo "Building Docker image ..."
-	docker build -t ${DOCKER_REGISTRY}/${DOCKER_ORG}/canary:${DOCKER_TAG} .
+	docker build -t ${DOCKER_REGISTRY}/${DOCKER_ORG}/${DOCKER_REPO}:${DOCKER_TAG} .
 
 docker_push:
 	echo "Pushing Docker image ..."
-	docker push ${DOCKER_REGISTRY}/${DOCKER_ORG}/canary:${DOCKER_TAG}
+	docker push ${DOCKER_REGISTRY}/${DOCKER_ORG}/${DOCKER_REPO}:${DOCKER_TAG}
 
 all: go_build docker_build docker_push
 


### PR DESCRIPTION
This PR allows changing the name of the built image via a `DOCKER_REPO` env var in the Makefile. Anyway, the default value is still `canary`.