### PR TITLE
Refactoring consumer service readiness

### DIFF
--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -106,8 +106,6 @@ func (cm *CanaryManager) reconcile() {
 
 	if result, err := cm.topicService.Reconcile(); err == nil {
 		if result.RefreshMetadata {
-			// consumer will subscribe to the topic so all partitions (even if we have less brokers)
-			cm.consumerService.Refresh(len(result.Assignments))
 			cm.producerService.Refresh()
 		}
 		// producer just needs to send from partition 0 to brokersNumber - 1


### PR DESCRIPTION
After digging into Sarama more this PR:

* changes the way to report back that consumer is ready. It's enough signaling in the `Setup` event and not for each consume claim
* no need to refresh metadata on consumer when assignments change, it adapts automatically