### PR TITLE
Added glog library for proper logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/Shopify/sarama v1.27.2
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/prometheus/client_golang v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -29,6 +29,7 @@ const (
 	ExpectedClusterSizeEnvVar         = "EXPECTED_CLUSTER_SIZE"
 	KafkaVersionEnvVar                = "KAFKA_VERSION"
 	SaramaLogEnabledEnvVar            = "SARAMA_LOG_ENABLED"
+	VerbosityLogLevelEnvVar           = "VERBOSITY_LOG_LEVEL"
 
 	// default values for environment variables
 	BootstrapServersDefault            = "localhost:9092"
@@ -44,6 +45,7 @@ const (
 	ExpectedClusterSizeDefault         = -1 // "dynamic" reassignment is enabled
 	KafkaVersionDefault                = "2.7.0"
 	SaramaLogEnabledDefault            = false
+	VerbosityLogLevelDefault           = 0 // default 0 = INFO, 1 = DEBUG, 2 = TRACE
 )
 
 // CanaryConfig defines the canary tool configuration
@@ -61,6 +63,7 @@ type CanaryConfig struct {
 	ExpectedClusterSize         int
 	KafkaVersion                string
 	SaramaLogEnabled            bool
+	VerbosityLogLevel           int
 }
 
 // NewCanaryConfig returns an configuration instance from environment variables
@@ -79,6 +82,7 @@ func NewCanaryConfig() *CanaryConfig {
 		ExpectedClusterSize:         lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
 		KafkaVersion:                lookupStringEnv(KafkaVersionEnvVar, KafkaVersionDefault),
 		SaramaLogEnabled:            lookupBoolEnv(SaramaLogEnabledEnvVar, SaramaLogEnabledDefault),
+		VerbosityLogLevel:           lookupIntEnv(VerbosityLogLevelEnvVar, VerbosityLogLevelDefault),
 	}
 	return &config
 }
@@ -125,7 +129,7 @@ func latencyBuckets(bucketsConfig string) []float64 {
 func (c CanaryConfig) String() string {
 	return fmt.Sprintf("{BootstrapServers:%s, BootstrapBackoffMaxAttempts:%d, BootstrapBackoffScale:%d, Topic:%s, ReconcileInterval:%d ms, "+
 		"ClientID:%s, ConsumerGroupID:%s, TLSEnabled:%t, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d, KafkaVersion:%s,"+
-		"SaramaLogEnabled:%t}",
+		"SaramaLogEnabled:%t, VerbosityLogLevel:%d}",
 		c.BootstrapServers, c.BootstrapBackoffMaxAttempts, c.BootstrapBackoffScale, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
-		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize, c.KafkaVersion, c.SaramaLogEnabled)
+		c.TLSEnabled, c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize, c.KafkaVersion, c.SaramaLogEnabled, c.VerbosityLogLevel)
 }

--- a/internal/servers/http_server.go
+++ b/internal/servers/http_server.go
@@ -8,10 +8,10 @@ package servers
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/strimzi/strimzi-canary/internal/services"
 )
@@ -37,7 +37,7 @@ func NewHttpServer() *HttpServer {
 
 // Start runs the HTTP server in its own go routine
 func (ms *HttpServer) Start() {
-	log.Printf("Starting HTTP server")
+	glog.Infof("Starting HTTP server")
 	go func() {
 		ms.httpServer.ListenAndServe()
 	}()
@@ -45,11 +45,11 @@ func (ms *HttpServer) Start() {
 
 // Stop stops the HTTP server exiting the go routine
 func (ms *HttpServer) Stop() {
-	log.Printf("Stopping HTTP server")
+	glog.Infof("Stopping HTTP server")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	ms.httpServer.Shutdown(ctx)
 
-	log.Printf("HTTP server closed")
+	glog.Infof("HTTP server closed")
 }


### PR DESCRIPTION
This PR fixes #4 and adds a proper logging framework (glog) for logging purposes with different verbosity log levels.
The main change is that all the log messages related to messages produced and consumed with corresponding latency are moved to a kind of verbosity level 1 (DEBUG) while all others are at 0 (INFO).
Notice that compared to how Java log4j framework works, the verbosity level here are like INFO, DEBUG and TRACE that in this specific case are mapped as 0,1 and 2.