### PR TITLE
Fixed producer sending to less partitions when less brokers

### DIFF
--- a/internal/services/producer.go
+++ b/internal/services/producer.go
@@ -65,8 +65,9 @@ func NewProducerService(canaryConfig *config.CanaryConfig, client sarama.Client)
 	return &ps
 }
 
-// Send sends one message to each partition from 0 to numPartitions specified as parameter
-func (ps *ProducerService) Send(numPartitions int) {
+// Send sends one message to partitions assigned to brokers
+func (ps *ProducerService) Send(partitionsAssignments map[int32][]int32) {
+	numPartitions := len(partitionsAssignments)
 	msg := &sarama.ProducerMessage{
 		Topic: ps.canaryConfig.Topic,
 	}

--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -50,8 +50,8 @@ func (cm *CanaryManager) Start() {
 		if result, err := cm.topicService.Reconcile(); err == nil {
 			// consumer will subscribe to the topic so all partitions (even if we have less brokers)
 			cm.consumerService.Consume()
-			// producer just needs to send from partition 0 to brokersNumber - 1
-			cm.producerService.Send(result.BrokersNumber)
+			// producer has to send to partitions assigned to brokers
+			cm.producerService.Send(result.Assignments)
 			break
 		} else if e, ok := err.(*services.ErrExpectedClusterSize); ok {
 			// if the "dynamic" reassignment is disabled, an error may occur with expected cluster size not met yet
@@ -105,8 +105,8 @@ func (cm *CanaryManager) reconcile() {
 		if result.RefreshMetadata {
 			cm.producerService.Refresh()
 		}
-		// producer just needs to send from partition 0 to brokersNumber - 1
-		cm.producerService.Send(result.BrokersNumber)
+		// producer has to send to partitions assigned to brokers
+		cm.producerService.Send(result.Assignments)
 	}
 
 	glog.Infof("... reconcile done")


### PR DESCRIPTION
This PR fixes #50.
With dynamic reassignment, the producer was sending to less partitions with brokers scaling down not reflecting what's the clients experience (all partitions still reachable even when a brokers goes down).