### PR TITLE
Added TLS connection support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,9 +91,6 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 	}
 
 	if canaryConfig.TLSEnabled {
-		if canaryConfig.TLSCACert == "" {
-			glog.Fatalf("TLS enabled but the CA certificate is not provided")
-		}
 		config.Net.TLS.Enable = true
 		if config.Net.TLS.Config, err = security.NewTLSConfig(canaryConfig); err != nil {
 			glog.Fatalf("Error configuring TLS: %v", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,7 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 
 	if canaryConfig.TLSEnabled {
 		if canaryConfig.TLSCACert == "" {
-			glog.Fatalf("TLS enabled but at leats the CA certificate is not provided")
+			glog.Fatalf("TLS enabled but the CA certificate is not provided")
 		}
 		config.Net.TLS.Enable = true
 		if config.Net.TLS.Config, err = security.NewTLSConfig(canaryConfig); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/strimzi/strimzi-canary/internal/config"
+	"github.com/strimzi/strimzi-canary/internal/security"
 	"github.com/strimzi/strimzi-canary/internal/servers"
 	"github.com/strimzi/strimzi-canary/internal/services"
 	"github.com/strimzi/strimzi-canary/internal/workers"
@@ -87,6 +88,16 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 
 	if canaryConfig.SaramaLogEnabled {
 		sarama.Logger = log.New(os.Stdout, "[Sarama] ", log.LstdFlags)
+	}
+
+	if canaryConfig.TLSEnabled {
+		if canaryConfig.TLSCACert == "" {
+			glog.Fatalf("TLS enabled but at leats the CA certificate is not provided")
+		}
+		config.Net.TLS.Enable = true
+		if config.Net.TLS.Config, err = security.NewTLSConfig(canaryConfig); err != nil {
+			glog.Fatalf("Error configuring TLS: %v", err)
+		}
 	}
 
 	backoff := services.NewBackoff(canaryConfig.BootstrapBackoffMaxAttempts, canaryConfig.BootstrapBackoffScale*time.Millisecond, services.MaxDefault)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -1,0 +1,66 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package security defining some security related tools
+package security
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/strimzi/strimzi-canary/internal/config"
+)
+
+func NewTLSConfig(canaryConfig *config.CanaryConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+
+	if canaryConfig.TLSCACert != "" {
+		if caCert, err := loadCertKey(config.TLSCACertEnvVar, canaryConfig.TLSCACert); err == nil {
+			tlsConfig.RootCAs = x509.NewCertPool()
+			tlsConfig.RootCAs.AppendCertsFromPEM(caCert)
+		} else {
+			return nil, err
+		}
+	}
+
+	if canaryConfig.TLSClientCert != "" && canaryConfig.TLSClientKey != "" {
+		var clientCert, clientKey []byte
+		var err error
+		var cert tls.Certificate
+
+		if clientCert, err = loadCertKey(config.TLSClientCertEnvVar, canaryConfig.TLSClientCert); err != nil {
+			return nil, err
+		}
+		if clientKey, err = loadCertKey(config.TLSClientKeyEnvVar, canaryConfig.TLSClientKey); err != nil {
+			return nil, err
+		}
+		if cert, err = tls.X509KeyPair(clientCert, clientKey); err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	tlsConfig.InsecureSkipVerify = canaryConfig.TLSInsecureSkipVerify
+
+	return tlsConfig, nil
+}
+
+func loadCertKey(config string, value string) ([]byte, error) {
+	var bytes []byte
+	// first check if the config is providing a file path to the certificate/key
+	if _, err := os.Stat(value); err == nil {
+		if bytes, err = ioutil.ReadFile(value); err != nil {
+			return nil, err
+		}
+		glog.Infof("%s loaded from file path: %s", config, value)
+	} else {
+		// otherwise the config contains the certificate/key directly
+		bytes = []byte(value)
+		glog.Infof("%s loaded from configuration directly", config)
+	}
+	return bytes, nil
+}


### PR DESCRIPTION
This PR fixes #9 
It allows to specify the TLS CA certificate, client and key directly in the corresponding env vars or using them to specify a path that could be mounted as a Secret (as it could be done by the Strimzi operator in the future and as it's already done for other components).
The code just configures the Sarama library with the corresponding TLS configuration.