### PR TITLE
Removed useless select on signal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,10 +63,8 @@ func main() {
 	canaryManager := workers.NewCanaryManager(canaryConfig, topicService, producerService, consumerService)
 	canaryManager.Start()
 
-	select {
-	case sig := <-signals:
-		glog.Infof("Got signal: %v", sig)
-	}
+	sig := <-signals
+	glog.Infof("Got signal: %v", sig)
 	canaryManager.Stop()
 	httpServer.Stop()
 


### PR DESCRIPTION
This PR removes a useless select on a channel because it's meant just to block waiting for interrupt signal and nothing more to select.