### PR TITLE
Fixing catch of SIGTERM instead of SIGKILL

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 	httpServer.Start()
 
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGKILL)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	client, err := newClient(canaryConfig)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the warning from the go-staticcheck:

`syscall.SIGKILL cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)go-staticcheck`

And anyway it's reported by the signal Go package documentation here https://golang.org/pkg/os/signal/ that SIGKILL cannot be caught.