### PR TITLE
Exiting consume loop before closing the client

### DIFF
--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -148,6 +148,7 @@ func (cs *ConsumerService) wait(timeout time.Duration) bool {
 // Close closes the underneath Sarama consumer group instance
 func (cs *ConsumerService) Close() {
 	glog.Infof("Closing consumer")
+	cs.cancel()
 	err := cs.consumerGroup.Close()
 	if err != nil {
 		glog.Fatalf("Error closing the Sarama consumer: %v", err)


### PR DESCRIPTION
Before closing the client, it's needed to cancel the context related to the consumer group and exiting the consume loop otherwise while closing, the Sarama library still tries to consume in the loop printing more lines like this:

```shell
I0523 16:45:41.631409   73771 consumer.go:171] Consumer group cleanup
I0523 16:45:41.631481   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631495   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631507   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631518   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631527   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631538   73771 consumer.go:97] Consumer group consume starting...
I0523 16:45:41.631548   73771 consumer.go:97] Consumer group consume starting...
```

This PR just cancel the context allowing to exit from the consume loop and then closing the client.