### PR TITLE
Running e2e tests with go test package notation

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -26,5 +26,4 @@ jobs:
 
       - name: Test
         run: |
-          cd test/
-          go test --tags=e2e
+          go test ./test/... --tags=e2e


### PR DESCRIPTION
Instead of entering the "test" folder, it's possible to run the command using the package as argument.