### PR TITLE
Added system certs unit test

### DIFF
--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -9,6 +9,7 @@
 package security
 
 import (
+	"crypto/x509"
 	"os"
 	"testing"
 
@@ -18,8 +19,12 @@ import (
 func TestSystemCertsPool(t *testing.T) {
 	os.Setenv(config.TLSEnabledEnvVar, "true")
 	canaryConfig := config.NewCanaryConfig()
-	_, e := NewTLSConfig(canaryConfig)
+	tlsConfig, e := NewTLSConfig(canaryConfig)
 	if e != nil {
+		t.Fail()
+	}
+	systemCertPool, _ := x509.SystemCertPool()
+	if len(tlsConfig.RootCAs.Subjects()) != len(systemCertPool.Subjects()) {
 		t.Fail()
 	}
 }

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,0 +1,25 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// +build unit_test
+
+// Package security defining some security related tools
+package security
+
+import (
+	"os"
+	"testing"
+
+	"github.com/strimzi/strimzi-canary/internal/config"
+)
+
+func TestSystemCertsPool(t *testing.T) {
+	os.Setenv(config.TLSEnabledEnvVar, "true")
+	canaryConfig := config.NewCanaryConfig()
+	_, e := NewTLSConfig(canaryConfig)
+	if e != nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This PR just adds a first unit test for security module when the TLS configuration is created without providing certs but using the system ones.
Other PRs will follow with provided certs.