### PR TITLE
Additional status checks for Kafka operations

### DIFF
--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -96,10 +96,8 @@ func (cs *ConsumerService) Consume() {
 
 				glog.Infof("Consumer group consume starting...")
 				// this method calls the methods handler on each stage: setup, consume and cleanup
-				err := cs.consumerGroup.Consume(ctx, []string{cs.canaryConfig.Topic}, cgh)
-
-				if err != nil {
-					glog.Infof("Error consuming topic: %v", err.Error())
+				if err := cs.consumerGroup.Consume(ctx, []string{cs.canaryConfig.Topic}, cgh); err != nil {
+					glog.Infof("Error consuming topic: %s", err.Error())
 					return
 				}
 

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -96,7 +96,12 @@ func (cs *ConsumerService) Consume() {
 
 				glog.Infof("Consumer group consume starting...")
 				// this method calls the methods handler on each stage: setup, consume and cleanup
-				cs.consumerGroup.Consume(ctx, []string{cs.canaryConfig.Topic}, cgh)
+				err := cs.consumerGroup.Consume(ctx, []string{cs.canaryConfig.Topic}, cgh)
+
+				if err != nil {
+					glog.Infof("Error consuming topic: %v", err.Error())
+					return
+				}
 
 				// check if context was cancelled, because of forcing a refresh metadata or exiting the consumer
 				if ctx.Err() != nil {

--- a/internal/services/producer.go
+++ b/internal/services/producer.go
@@ -90,7 +90,7 @@ func (ps *ProducerService) Send(partitionsAssignments map[int32][]int32) {
 		}
 		recordsProduced.With(labels).Inc()
 		if err != nil {
-			glog.Warningf("Erros sending message: %v", err)
+			glog.Warningf("Error sending message: %v", err)
 			recordsProducedFailed.With(labels).Inc()
 		} else {
 			duration := timestamp - cm.Timestamp

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -167,7 +167,7 @@ func (ts *TopicService) Reconcile() (TopicReconcileResult, error) {
 			"topic": ts.canaryConfig.Topic,
 		}
 		describeTopicError.With(labels).Inc()
-		glog.Errorf("Error retrieving metadata for topic %s: %v", ts.canaryConfig.Topic, topicMetadata.Err.Error())
+		glog.Errorf("Error retrieving metadata for topic %s: %s", ts.canaryConfig.Topic, topicMetadata.Err.Error())
 		return result, topicMetadata.Err
 	}
 

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -138,8 +138,7 @@ func (ts *TopicService) Reconcile() (TopicReconcileResult, error) {
 			// not creating the topic and returning error to avoid starting producer/consumer
 			return result, &ErrExpectedClusterSize{}
 		}
-
-	} else {
+	} else if topicMetadata.Err == sarama.ErrNoError {
 		// canary topic already exists, check replicas assignments
 		glog.V(1).Infof("The canary topic %s already exists", topicMetadata.Name)
 		logTopicMetadata(topicMetadata)
@@ -163,8 +162,15 @@ func (ts *TopicService) Reconcile() (TopicReconcileResult, error) {
 		} else {
 			result.Assignments = ts.currentAssignments(topicMetadata)
 		}
-
+	} else {
+		labels := prometheus.Labels{
+			"topic": ts.canaryConfig.Topic,
+		}
+		describeTopicError.With(labels).Inc()
+		glog.Errorf("Error retrieving metadata for topic %s: %v", ts.canaryConfig.Topic, topicMetadata.Err.Error())
+		return result, topicMetadata.Err
 	}
+
 	ts.initialized = true
 	return result, err
 }


### PR DESCRIPTION
This PR adds status checking in two additional places - after describing the Canary's topic and when consuming from the topic.

Signed-off-by: Michael Edgar <medgar@redhat.com>