### PR TITLE
Added connection check service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,8 +59,9 @@ func main() {
 	topicService := services.NewTopicService(canaryConfig, client)
 	producerService := services.NewProducerService(canaryConfig, client)
 	consumerService := services.NewConsumerService(canaryConfig, client)
+	connectionService := services.NewConnectionService(canaryConfig, client)
 
-	canaryManager := workers.NewCanaryManager(canaryConfig, topicService, producerService, consumerService)
+	canaryManager := workers.NewCanaryManager(canaryConfig, topicService, producerService, consumerService, connectionService)
 	canaryManager.Start()
 
 	sig := <-signals

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -19,101 +19,109 @@ import (
 
 const (
 	// environment variables declaration
-	BootstrapServersEnvVar            = "KAFKA_BOOTSTRAP_SERVERS"
-	BootstrapBackoffMaxAttemptsEnvVar = "KAFKA_BOOTSTRAP_BACKOFF_MAX_ATTEMPTS"
-	BootstrapBackoffScaleEnvVar       = "KAFKA_BOOTSTRAP_BACKOFF_SCALE"
-	TopicEnvVar                       = "TOPIC"
-	ReconcileIntervalEnvVar           = "RECONCILE_INTERVAL_MS"
-	ClientIDEnvVar                    = "CLIENT_ID"
-	ConsumerGroupIDEnvVar             = "CONSUMER_GROUP_ID"
-	ProducerLatencyBucketsEnvVar      = "PRODUCER_LATENCY_BUCKETS"
-	EndToEndLatencyBucketsEnvVar      = "ENDTOEND_LATENCY_BUCKETS"
-	ExpectedClusterSizeEnvVar         = "EXPECTED_CLUSTER_SIZE"
-	KafkaVersionEnvVar                = "KAFKA_VERSION"
-	SaramaLogEnabledEnvVar            = "SARAMA_LOG_ENABLED"
-	VerbosityLogLevelEnvVar           = "VERBOSITY_LOG_LEVEL"
-	TLSEnabledEnvVar                  = "TLS_ENABLED"
-	TLSCACertEnvVar                   = "TLS_CA_CERT"
-	TLSClientCertEnvVar               = "TLS_CLIENT_CERT"
-	TLSClientKeyEnvVar                = "TLS_CLIENT_KEY"
-	TLSInsecureSkipVerifyEnvVar       = "TLS_INSECURE_SKIP_VERIFY"
-	SASLMechanismEnvVar               = "SASL_MECHANISM"
-	SASLUserEnvVar                    = "SASL_USER"
-	SASLPasswordEnvVar                = "SASL_PASSWORD"
+	BootstrapServersEnvVar              = "KAFKA_BOOTSTRAP_SERVERS"
+	BootstrapBackoffMaxAttemptsEnvVar   = "KAFKA_BOOTSTRAP_BACKOFF_MAX_ATTEMPTS"
+	BootstrapBackoffScaleEnvVar         = "KAFKA_BOOTSTRAP_BACKOFF_SCALE"
+	TopicEnvVar                         = "TOPIC"
+	ReconcileIntervalEnvVar             = "RECONCILE_INTERVAL_MS"
+	ClientIDEnvVar                      = "CLIENT_ID"
+	ConsumerGroupIDEnvVar               = "CONSUMER_GROUP_ID"
+	ProducerLatencyBucketsEnvVar        = "PRODUCER_LATENCY_BUCKETS"
+	EndToEndLatencyBucketsEnvVar        = "ENDTOEND_LATENCY_BUCKETS"
+	ExpectedClusterSizeEnvVar           = "EXPECTED_CLUSTER_SIZE"
+	KafkaVersionEnvVar                  = "KAFKA_VERSION"
+	SaramaLogEnabledEnvVar              = "SARAMA_LOG_ENABLED"
+	VerbosityLogLevelEnvVar             = "VERBOSITY_LOG_LEVEL"
+	TLSEnabledEnvVar                    = "TLS_ENABLED"
+	TLSCACertEnvVar                     = "TLS_CA_CERT"
+	TLSClientCertEnvVar                 = "TLS_CLIENT_CERT"
+	TLSClientKeyEnvVar                  = "TLS_CLIENT_KEY"
+	TLSInsecureSkipVerifyEnvVar         = "TLS_INSECURE_SKIP_VERIFY"
+	SASLMechanismEnvVar                 = "SASL_MECHANISM"
+	SASLUserEnvVar                      = "SASL_USER"
+	SASLPasswordEnvVar                  = "SASL_PASSWORD"
+	ConnectionCheckIntervalEnvVar       = "CONNECTION_CHECK_INTERVAL_MS"
+	ConnectionCheckLatencyBucketsEnvVar = "CONNECTION_CHECK_LATENCY_BUCKETS"
 
 	// default values for environment variables
-	BootstrapServersDefault            = "localhost:9092"
-	BootstrapBackoffMaxAttemptsDefault = 10
-	BootstrapBackoffScaleDefault       = 5000
-	TopicDefault                       = "__strimzi_canary"
-	ReconcileIntervalDefault           = 30000
-	ClientIDDefault                    = "strimzi-canary-client"
-	ConsumerGroupIDDefault             = "strimzi-canary-group"
-	ProducerLatencyBucketsDefault      = "100,200,400,800,1600"
-	EndToEndLatencyBucketsDefault      = "100,200,400,800,1600"
-	ExpectedClusterSizeDefault         = -1 // "dynamic" reassignment is enabled
-	KafkaVersionDefault                = "2.8.0"
-	SaramaLogEnabledDefault            = false
-	VerbosityLogLevelDefault           = 0 // default 0 = INFO, 1 = DEBUG, 2 = TRACE
-	TLSEnabledDefault                  = false
-	TLSCACertDefault                   = ""
-	TLSClientCertDefault               = ""
-	TLSClientKeyDefault                = ""
-	TLSInsecureSkipVerifyDefault       = false
-	SASLMechanismDefault               = ""
-	SASLUserDefault                    = ""
-	SASLPasswordDefault                = ""
+	BootstrapServersDefault              = "localhost:9092"
+	BootstrapBackoffMaxAttemptsDefault   = 10
+	BootstrapBackoffScaleDefault         = 5000
+	TopicDefault                         = "__strimzi_canary"
+	ReconcileIntervalDefault             = 30000
+	ClientIDDefault                      = "strimzi-canary-client"
+	ConsumerGroupIDDefault               = "strimzi-canary-group"
+	ProducerLatencyBucketsDefault        = "100,200,400,800,1600"
+	EndToEndLatencyBucketsDefault        = "100,200,400,800,1600"
+	ExpectedClusterSizeDefault           = -1 // "dynamic" reassignment is enabled
+	KafkaVersionDefault                  = "2.8.0"
+	SaramaLogEnabledDefault              = false
+	VerbosityLogLevelDefault             = 0 // default 0 = INFO, 1 = DEBUG, 2 = TRACE
+	TLSEnabledDefault                    = false
+	TLSCACertDefault                     = ""
+	TLSClientCertDefault                 = ""
+	TLSClientKeyDefault                  = ""
+	TLSInsecureSkipVerifyDefault         = false
+	SASLMechanismDefault                 = ""
+	SASLUserDefault                      = ""
+	SASLPasswordDefault                  = ""
+	ConnectionCheckIntervalDefault       = 120000
+	ConnectionCheckLatencyBucketsDefault = "100,200,400,800,1600"
 )
 
 // CanaryConfig defines the canary tool configuration
 type CanaryConfig struct {
-	BootstrapServers            string
-	BootstrapBackoffMaxAttempts int
-	BootstrapBackoffScale       time.Duration
-	Topic                       string
-	ReconcileInterval           time.Duration
-	ClientID                    string
-	ConsumerGroupID             string
-	ProducerLatencyBuckets      []float64
-	EndToEndLatencyBuckets      []float64
-	ExpectedClusterSize         int
-	KafkaVersion                string
-	SaramaLogEnabled            bool
-	VerbosityLogLevel           int
-	TLSEnabled                  bool
-	TLSCACert                   string
-	TLSClientCert               string
-	TLSClientKey                string
-	TLSInsecureSkipVerify       bool
-	SASLMechanism               string
-	SASLUser                    string
-	SASLPassword                string
+	BootstrapServers              string
+	BootstrapBackoffMaxAttempts   int
+	BootstrapBackoffScale         time.Duration
+	Topic                         string
+	ReconcileInterval             time.Duration
+	ClientID                      string
+	ConsumerGroupID               string
+	ProducerLatencyBuckets        []float64
+	EndToEndLatencyBuckets        []float64
+	ExpectedClusterSize           int
+	KafkaVersion                  string
+	SaramaLogEnabled              bool
+	VerbosityLogLevel             int
+	TLSEnabled                    bool
+	TLSCACert                     string
+	TLSClientCert                 string
+	TLSClientKey                  string
+	TLSInsecureSkipVerify         bool
+	SASLMechanism                 string
+	SASLUser                      string
+	SASLPassword                  string
+	ConnectionCheckInterval       time.Duration
+	ConnectionCheckLatencyBuckets []float64
 }
 
 // NewCanaryConfig returns an configuration instance from environment variables
 func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
-		BootstrapServers:            lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
-		BootstrapBackoffMaxAttempts: lookupIntEnv(BootstrapBackoffMaxAttemptsEnvVar, BootstrapBackoffMaxAttemptsDefault),
-		BootstrapBackoffScale:       time.Duration(lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault)),
-		Topic:                       lookupStringEnv(TopicEnvVar, TopicDefault),
-		ReconcileInterval:           time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
-		ClientID:                    lookupStringEnv(ClientIDEnvVar, ClientIDDefault),
-		ConsumerGroupID:             lookupStringEnv(ConsumerGroupIDEnvVar, ConsumerGroupIDDefault),
-		ProducerLatencyBuckets:      latencyBuckets(lookupStringEnv(ProducerLatencyBucketsEnvVar, ProducerLatencyBucketsDefault)),
-		EndToEndLatencyBuckets:      latencyBuckets(lookupStringEnv(EndToEndLatencyBucketsEnvVar, EndToEndLatencyBucketsDefault)),
-		ExpectedClusterSize:         lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
-		KafkaVersion:                lookupStringEnv(KafkaVersionEnvVar, KafkaVersionDefault),
-		SaramaLogEnabled:            lookupBoolEnv(SaramaLogEnabledEnvVar, SaramaLogEnabledDefault),
-		VerbosityLogLevel:           lookupIntEnv(VerbosityLogLevelEnvVar, VerbosityLogLevelDefault),
-		TLSEnabled:                  lookupBoolEnv(TLSEnabledEnvVar, TLSEnabledDefault),
-		TLSCACert:                   lookupStringEnv(TLSCACertEnvVar, TLSCACertDefault),
-		TLSClientCert:               lookupStringEnv(TLSClientCertEnvVar, TLSClientCertDefault),
-		TLSClientKey:                lookupStringEnv(TLSClientKeyEnvVar, TLSClientKeyDefault),
-		TLSInsecureSkipVerify:       lookupBoolEnv(TLSInsecureSkipVerifyEnvVar, TLSInsecureSkipVerifyDefault),
-		SASLMechanism:               lookupStringEnv(SASLMechanismEnvVar, SASLMechanismDefault),
-		SASLUser:                    lookupStringEnv(SASLUserEnvVar, SASLUserDefault),
-		SASLPassword:                lookupStringEnv(SASLPasswordEnvVar, SASLPasswordDefault),
+		BootstrapServers:              lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
+		BootstrapBackoffMaxAttempts:   lookupIntEnv(BootstrapBackoffMaxAttemptsEnvVar, BootstrapBackoffMaxAttemptsDefault),
+		BootstrapBackoffScale:         time.Duration(lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault)),
+		Topic:                         lookupStringEnv(TopicEnvVar, TopicDefault),
+		ReconcileInterval:             time.Duration(lookupIntEnv(ReconcileIntervalEnvVar, ReconcileIntervalDefault)),
+		ClientID:                      lookupStringEnv(ClientIDEnvVar, ClientIDDefault),
+		ConsumerGroupID:               lookupStringEnv(ConsumerGroupIDEnvVar, ConsumerGroupIDDefault),
+		ProducerLatencyBuckets:        latencyBuckets(lookupStringEnv(ProducerLatencyBucketsEnvVar, ProducerLatencyBucketsDefault)),
+		EndToEndLatencyBuckets:        latencyBuckets(lookupStringEnv(EndToEndLatencyBucketsEnvVar, EndToEndLatencyBucketsDefault)),
+		ExpectedClusterSize:           lookupIntEnv(ExpectedClusterSizeEnvVar, ExpectedClusterSizeDefault),
+		KafkaVersion:                  lookupStringEnv(KafkaVersionEnvVar, KafkaVersionDefault),
+		SaramaLogEnabled:              lookupBoolEnv(SaramaLogEnabledEnvVar, SaramaLogEnabledDefault),
+		VerbosityLogLevel:             lookupIntEnv(VerbosityLogLevelEnvVar, VerbosityLogLevelDefault),
+		TLSEnabled:                    lookupBoolEnv(TLSEnabledEnvVar, TLSEnabledDefault),
+		TLSCACert:                     lookupStringEnv(TLSCACertEnvVar, TLSCACertDefault),
+		TLSClientCert:                 lookupStringEnv(TLSClientCertEnvVar, TLSClientCertDefault),
+		TLSClientKey:                  lookupStringEnv(TLSClientKeyEnvVar, TLSClientKeyDefault),
+		TLSInsecureSkipVerify:         lookupBoolEnv(TLSInsecureSkipVerifyEnvVar, TLSInsecureSkipVerifyDefault),
+		SASLMechanism:                 lookupStringEnv(SASLMechanismEnvVar, SASLMechanismDefault),
+		SASLUser:                      lookupStringEnv(SASLUserEnvVar, SASLUserDefault),
+		SASLPassword:                  lookupStringEnv(SASLPasswordEnvVar, SASLPasswordDefault),
+		ConnectionCheckInterval:       time.Duration(lookupIntEnv(ConnectionCheckIntervalEnvVar, ConnectionCheckIntervalDefault)),
+		ConnectionCheckLatencyBuckets: latencyBuckets(lookupStringEnv(ConnectionCheckLatencyBucketsEnvVar, ConnectionCheckLatencyBucketsDefault)),
 	}
 	return &config
 }
@@ -189,8 +197,9 @@ func (c CanaryConfig) String() string {
 	return fmt.Sprintf("{BootstrapServers:%s, BootstrapBackoffMaxAttempts:%d, BootstrapBackoffScale:%d, Topic:%s, ReconcileInterval:%d ms, "+
 		"ClientID:%s, ConsumerGroupID:%s, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d, KafkaVersion:%s,"+
 		"SaramaLogEnabled:%t, VerbosityLogLevel:%d, TLSEnabled:%t, TLSCACert:%s, TLSClientCert:%s, TLSClientKey:%s, TLSInsecureSkipVerify:%t,"+
-		"SASLMechanism:%s, SASLUser:%s, SASLPassword:%s}",
+		"SASLMechanism:%s, SASLUser:%s, SASLPassword:%s, ConnectionCheckInterval:%d ms, ConnectionCheckLatencyBuckets:%v}",
 		c.BootstrapServers, c.BootstrapBackoffMaxAttempts, c.BootstrapBackoffScale, c.Topic, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
 		c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize, c.KafkaVersion, c.SaramaLogEnabled, c.VerbosityLogLevel,
-		c.TLSEnabled, TLSCACert, TLSClientCert, TLSClientKey, c.TLSInsecureSkipVerify, c.SASLMechanism, SASLUser, SASLPassword)
+		c.TLSEnabled, TLSCACert, TLSClientCert, TLSClientKey, c.TLSInsecureSkipVerify, c.SASLMechanism, SASLUser, SASLPassword,
+		c.ConnectionCheckInterval, c.ConnectionCheckLatencyBuckets)
 }

--- a/internal/config/canary_config_test.go
+++ b/internal/config/canary_config_test.go
@@ -39,6 +39,9 @@ func TestConfigDefault(t *testing.T) {
 	assertStringConfigParameter(c.SASLMechanism, SASLMechanismDefault, t)
 	assertStringConfigParameter(c.SASLUser, SASLUserDefault, t)
 	assertStringConfigParameter(c.SASLPassword, SASLPasswordDefault, t)
+	assertDurationConfigParameter(c.ConnectionCheckInterval, ConnectionCheckIntervalDefault, t)
+	connectionCheckLatencyBucketsDefault := latencyBuckets(ConnectionCheckLatencyBucketsDefault)
+	assertBucketsConfigParameter(c.ConnectionCheckLatencyBuckets, connectionCheckLatencyBucketsDefault, t)
 }
 
 func TestConfigCustom(t *testing.T) {
@@ -63,6 +66,8 @@ func TestConfigCustom(t *testing.T) {
 	os.Setenv(SASLMechanismEnvVar, "PLAIN")
 	os.Setenv(SASLUserEnvVar, "user")
 	os.Setenv(SASLPasswordEnvVar, "password")
+	os.Setenv(ConnectionCheckIntervalEnvVar, "20000")
+	os.Setenv(ConnectionCheckLatencyBucketsEnvVar, "200,400,800")
 	c := NewCanaryConfig()
 	assertStringConfigParameter(c.BootstrapServers, "my-cluster-kafka:9092", t)
 	assertIntConfigParameter(c.BootstrapBackoffMaxAttempts, 3, t)
@@ -87,6 +92,9 @@ func TestConfigCustom(t *testing.T) {
 	assertStringConfigParameter(c.SASLMechanism, "PLAIN", t)
 	assertStringConfigParameter(c.SASLUser, "user", t)
 	assertStringConfigParameter(c.SASLPassword, "password", t)
+	assertDurationConfigParameter(c.ConnectionCheckInterval, 20000, t)
+	connectionCheckLatencyBuckets := latencyBuckets("200,400,800")
+	assertBucketsConfigParameter(c.ConnectionCheckLatencyBuckets, connectionCheckLatencyBuckets, t)
 }
 
 func assertStringConfigParameter(value string, defaultValue string, t *testing.T) {

--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -1,0 +1,148 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+// Package services defines some canary related services
+package services
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/strimzi/strimzi-canary/internal/config"
+)
+
+var (
+	connectionError = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "connection_error_total",
+		Namespace: "strimzi_canary",
+		Help:      "Total number of errors while checking the connection to Kafka brokers",
+	}, []string{"brokerid"})
+
+	// it's defined when the service is created because buckets are configurable
+	connectionLatency *prometheus.HistogramVec
+)
+
+type ConnectionService struct {
+	canaryConfig *config.CanaryConfig
+	client       sarama.Client
+	admin        sarama.ClusterAdmin
+	brokers      []*sarama.Broker
+	stop         chan struct{}
+	syncStop     sync.WaitGroup
+}
+
+// NewConnectionService returns an instance of ConnectionService
+func NewConnectionService(canaryConfig *config.CanaryConfig, client sarama.Client) *ConnectionService {
+	connectionLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "connection_latency",
+		Namespace: "strimzi_canary",
+		Help:      "Connection latency in milliseconds",
+		Buckets:   canaryConfig.ConnectionCheckLatencyBuckets,
+	}, []string{"brokerid"})
+
+	admin, err := sarama.NewClusterAdminFromClient(client)
+	if err != nil {
+		glog.Fatalf("Error creating the Sarama cluster admin: %v", err)
+	}
+	cs := ConnectionService{
+		canaryConfig: canaryConfig,
+		client:       client,
+		admin:        admin,
+	}
+	return &cs
+}
+
+// Open starts the connection check loop
+func (cs *ConnectionService) Open() {
+	cs.stop = make(chan struct{})
+	cs.syncStop.Add(1)
+
+	cs.connectionCheck()
+
+	ticker := time.NewTicker(cs.canaryConfig.ConnectionCheckInterval * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				cs.connectionCheck()
+			case <-cs.stop:
+				ticker.Stop()
+				defer cs.syncStop.Done()
+				glog.Infof("Stopping connection check loop")
+				return
+			}
+		}
+	}()
+}
+
+// Close stops the connection check loop and closes the underneath Sarama admin instance
+func (cs *ConnectionService) Close() {
+	glog.Infof("Closing connection check service")
+
+	// ask to stop the ticker reconcile loop and wait
+	close(cs.stop)
+	cs.syncStop.Wait()
+
+	if err := cs.admin.Close(); err != nil {
+		glog.Fatalf("Error closing the Sarama cluster admin: %v", err)
+	}
+	glog.Infof("Connection check service closed")
+}
+
+// connectionCheck does a connection check to the Kafka brokers
+//
+// It uses the Sarama admin client to get brokers metadata and then the low level Broker "object" in order to:
+//
+// 1. open a connection
+// 2. check if the connection was ok
+// 3. close the connection
+//
+// When the expected cluster size is set, the connection check service gets the brokers metadata just on the first check
+// in order to report connection errors when one of them is down. When the expected cluster size is not set (canary
+// handles the topic partitions reassignment process when Kafka cluster scales), the connection check service gets the brokers
+// metadata on each check so it doesn't try to connect to not running brokers (the user could have scaled down the cluster).
+//
+// It also reports the time needed to open a connection successfully or connection errors as metrics.
+func (cs *ConnectionService) connectionCheck() {
+	var err error
+
+	if cs.isDynamicScalingEnabled() || cs.brokers == nil {
+		cs.brokers, _, err = cs.admin.DescribeCluster()
+		if err != nil {
+			glog.Errorf("Error describing cluster: %v", err)
+			return
+		}
+	}
+
+	for _, b := range cs.brokers {
+		start := time.Now().UnixNano() / 1000000 // timestamp in milliseconds
+		// ignore error because it will be reported by Connected() call if "not connected"
+		b.Open(cs.client.Config())
+
+		labels := prometheus.Labels{
+			"brokerid": strconv.Itoa(int(b.ID())),
+		}
+
+		if connected, err := b.Connected(); !connected {
+			connectionError.With(labels).Inc()
+			glog.V(1).Infof("Connected broker %d [%t] error [%v]", b.ID(), connected, err)
+		} else {
+			duration := (time.Now().UnixNano() / 1000000) - start
+			connectionLatency.With(labels).Observe(float64(duration))
+			glog.V(1).Infof("Connected broker %d [%t] in [%d] ms", b.ID(), connected, duration)
+			b.Close()
+		}
+	}
+}
+
+// If the "dynamic" scaling is enabled
+func (cs *ConnectionService) isDynamicScalingEnabled() bool {
+	return cs.canaryConfig.ExpectedClusterSize == config.ExpectedClusterSizeDefault
+}


### PR DESCRIPTION
This PR fixes #84.
It adds a new internal service that periodically check connections to the Kafka brokers in the cluster in order to measure latency the reported via corresponding metrics. 