### PR TITLE
Added documentation about env vars related to the connection checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ When running the Strimzi canary tool, it is possible to configure different aspe
 * `TLS_INSECURE_SKIP_VERIFY`:  if the underneath Sarama client has to verify the server's certificate chain and host name. Default `false`.
 * `SASL_MECHANISM`: mechanism to use for SASL authentication against the Kafka cluster. Default empty.
 * `SASL_USER`: username for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty.
-* `SASL_PASSWORD`: password for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty..
+* `SASL_PASSWORD`: password for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty.
+* `CONNECTION_CHECK_INTERVAL_MS`: it defines how often the tool has to check the connection with brokers (in ms). Default `120000`.
+* `CONNECTION_CHECK_LATENCY_BUCKETS`: buckets of the hystogram related to the brokers connection latency metric (in ms). Default `100,200,400,800,1600`. 
 
 ## Build
 


### PR DESCRIPTION
This adds the documentation about the env var for configuring the connection checker added via https://github.com/strimzi/strimzi-canary/pull/85