### PR TITLE
Logging connection error out of the DEBUG verbosity level

### DIFF
--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -137,11 +137,12 @@ func (cs *ConnectionService) connectionCheck() {
 
 		if connected {
 			b.Close()
+			glog.V(1).Infof("Connected to broker %d in %d ms", b.ID(), duration)
 		} else {
 			connectionError.With(labels).Inc()
+			glog.Errorf("Error connecting to broker %d in %d ms (error [%v])", b.ID(), duration, err)
 		}
 		connectionLatency.With(labels).Observe(float64(duration))
-		glog.V(1).Infof("Connection to broker %d [%t] in [%d] ms (error [%v])", b.ID(), connected, duration, err)
 	}
 }
 


### PR DESCRIPTION
I noticed that a connection error in the connection checker was printed only at verbosity DEBUG level enabled while as an error it would be important to be there anyway.