### PR TITLE
Fixed metric name for canary connection latency

### DIFF
--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -42,7 +42,7 @@ type ConnectionService struct {
 // NewConnectionService returns an instance of ConnectionService
 func NewConnectionService(canaryConfig *config.CanaryConfig, client sarama.Client) *ConnectionService {
 	connectionLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:      "connection_success_latency",
+		Name:      "connection_latency",
 		Namespace: "strimzi_canary",
 		Help:      "Latency in milliseconds for established or failed connections",
 		Buckets:   canaryConfig.ConnectionCheckLatencyBuckets,


### PR DESCRIPTION
The connection latency metric is about succeeded and failed connections so it's name has to be a generic `connection_latency` (not `connection_success_latency`) even because a tag is used to discriminate success or not. 