### PR TITLE
Fixed bootstrap servers usage as comma separated list of servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is achieved by creating a canary topic and periodically producing and consu
 
 When running the Strimzi canary tool, it is possible to configure different aspects by using the following environment variables.
 
-* `KAFKA_BOOTSTRAP_SERVERS`: the bootstrap servers list for the Kafka cluster to connect to. Default `localhost:9092`.
+* `KAFKA_BOOTSTRAP_SERVERS`: comma separated bootstrap servers of the Kafka cluster to connect to. Default `localhost:9092`.
 * `KAFKA_BOOTSTRAP_BACKOFF_MAX_ATTEMPTS`: maximum numeber of attempts for connecting to the Kafka cluster if it is not ready yet. Defualt `10`.
 * `KAFKA_BOOTSTRAP_BACKOFF_SCALE`: the scale used to delay between attempts to connect to the Kafka cluster (in ms). Default `5000`.
 * `TOPIC`: the name of the topic used by the tool to send and receive messages. Default `__strimzi_canary`.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,7 +104,7 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 
 	backoff := services.NewBackoff(canaryConfig.BootstrapBackoffMaxAttempts, canaryConfig.BootstrapBackoffScale*time.Millisecond, services.MaxDefault)
 	for {
-		client, clientErr := sarama.NewClient([]string{canaryConfig.BootstrapServers}, config)
+		client, clientErr := sarama.NewClient(canaryConfig.BootstrapServers, config)
 		if clientErr == nil {
 			return client, nil
 		}

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -71,7 +71,7 @@ const (
 
 // CanaryConfig defines the canary tool configuration
 type CanaryConfig struct {
-	BootstrapServers              string
+	BootstrapServers              []string
 	BootstrapBackoffMaxAttempts   int
 	BootstrapBackoffScale         time.Duration
 	Topic                         string
@@ -99,7 +99,7 @@ type CanaryConfig struct {
 // NewCanaryConfig returns an configuration instance from environment variables
 func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
-		BootstrapServers:              lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault),
+		BootstrapServers:              strings.Split(lookupStringEnv(BootstrapServersEnvVar, BootstrapServersDefault), ","),
 		BootstrapBackoffMaxAttempts:   lookupIntEnv(BootstrapBackoffMaxAttemptsEnvVar, BootstrapBackoffMaxAttemptsDefault),
 		BootstrapBackoffScale:         time.Duration(lookupIntEnv(BootstrapBackoffScaleEnvVar, BootstrapBackoffScaleDefault)),
 		Topic:                         lookupStringEnv(TopicEnvVar, TopicDefault),

--- a/internal/config/canary_config_test.go
+++ b/internal/config/canary_config_test.go
@@ -47,7 +47,7 @@ func TestConfigDefault(t *testing.T) {
 }
 
 func TestConfigCustom(t *testing.T) {
-	os.Setenv(BootstrapServersEnvVar, "my-cluster-kafka:9092,my-cluster-kafka:9093")
+	os.Setenv(BootstrapServersEnvVar, "kafka-broker-1:9092,kafka-broker-2:9092")
 	os.Setenv(BootstrapBackoffMaxAttemptsEnvVar, "3")
 	os.Setenv(BootstrapBackoffScaleEnvVar, "1000")
 	os.Setenv(TopicEnvVar, "my-strimzi-canary-topic")
@@ -71,7 +71,7 @@ func TestConfigCustom(t *testing.T) {
 	os.Setenv(ConnectionCheckIntervalEnvVar, "20000")
 	os.Setenv(ConnectionCheckLatencyBucketsEnvVar, "200,400,800")
 	c := NewCanaryConfig()
-	bootstrapServers := strings.Split("my-cluster-kafka:9092,my-cluster-kafka:9093", ",")
+	bootstrapServers := strings.Split("kafka-broker-1:9092,kafka-broker-2:9092", ",")
 	assertStringSlicesConfigParameter(c.BootstrapServers, bootstrapServers, t)
 	assertIntConfigParameter(c.BootstrapBackoffMaxAttempts, 3, t)
 	assertDurationConfigParameter(c.BootstrapBackoffScale, 1000, t)


### PR DESCRIPTION
This PR fixes #95 using the bootstrap servers parameter as a comma separated list of servers.