### PR TITLE
Strict validation of the topic configuration parameter

### DIFF
--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -100,7 +100,7 @@ type CanaryConfig struct {
 	ConnectionCheckLatencyBuckets []float64
 }
 
-var topicConfigRegex = regexp.MustCompile(`([\w\.]+)=([\w,]+)`)
+var topicConfigRegex = regexp.MustCompile(`([\w\.]+)=([\w,]+)(?:;|$)`)
 
 // NewCanaryConfig returns an configuration instance from environment variables
 func NewCanaryConfig() *CanaryConfig {

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -184,7 +184,7 @@ func topicConfig(topicConfig string) map[string]string {
 		kv := strings.Split(kvPair, "=")
 		// key-value pair split has to have two fields (key has to be not empty)
 		if len(kv) != 2 || len(kv[0]) == 0 {
-			glog.Fatalf("Error parsing topic configuration [%s]: [%s] is not a valid key-value pair", topicConfig, kvPair)
+			panic(fmt.Errorf("error parsing topic configuration [%s]: [%s] is not a valid key-value pair", topicConfig, kvPair))
 		}
 		mapTopicConfig[kv[0]] = kv[1]
 	}

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -9,7 +9,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -100,8 +99,6 @@ type CanaryConfig struct {
 	ConnectionCheckLatencyBuckets []float64
 }
 
-var topicConfigRegex = regexp.MustCompile(`([\w\.]+)=([\w,]+)(?:;|$)`)
-
 // NewCanaryConfig returns an configuration instance from environment variables
 func NewCanaryConfig() *CanaryConfig {
 	var config CanaryConfig = CanaryConfig{
@@ -176,13 +173,20 @@ func topicConfig(topicConfig string) map[string]string {
 	if len(topicConfig) == 0 {
 		return nil
 	}
-	matches := topicConfigRegex.FindAllStringSubmatch(topicConfig, -1)
 
 	mapTopicConfig := make(map[string]string)
-	for _, kv := range matches {
-		k := kv[1]
-		v := kv[2]
-		mapTopicConfig[k] = v
+	kvPairs := strings.Split(topicConfig, ";")
+	for i, kvPair := range kvPairs {
+		// just exits if latest kvPair is empty (allows trailing ";")
+		if i == len(kvPairs)-1 && len(kvPair) == 0 {
+			break
+		}
+		kv := strings.Split(kvPair, "=")
+		// key-value pair split has to have two fields (key has to be not empty)
+		if len(kv) != 2 || len(kv[0]) == 0 {
+			glog.Fatalf("Error parsing topic configuration [%s]: [%s] is not a valid key-value pair", topicConfig, kvPair)
+		}
+		mapTopicConfig[kv[0]] = kv[1]
 	}
 	return mapTopicConfig
 }

--- a/internal/config/canary_config_test.go
+++ b/internal/config/canary_config_test.go
@@ -105,6 +105,27 @@ func TestConfigCustom(t *testing.T) {
 	assertBucketsConfigParameter(c.ConnectionCheckLatencyBuckets, connectionCheckLatencyBuckets, t)
 }
 
+func TestTopicConfigurationNoKey(t *testing.T) {
+	defer func() { recover() }()
+	os.Setenv(TopicConfigEnvVar, "=600000;segment.bytes=16384;cleanup.policy=compact,delete")
+	NewCanaryConfig()
+	t.Errorf("Should have been panicked!")
+}
+
+func TestTopicConfigurationInvalidKeyValuePair(t *testing.T) {
+	defer func() { recover() }()
+	os.Setenv(TopicConfigEnvVar, "aaaaa;segment.bytes=16384;cleanup.policy=compact,delete")
+	NewCanaryConfig()
+	t.Errorf("Should have been panicked!")
+}
+
+func TestTopicConfigurationEmptyKeyValuePair(t *testing.T) {
+	defer func() { recover() }()
+	os.Setenv(TopicConfigEnvVar, ";;;;segment.bytes=16384;cleanup.policy=compact,delete")
+	NewCanaryConfig()
+	t.Errorf("Should have been panicked!")
+}
+
 func assertStringSlicesConfigParameter(value []string, defaultValue []string, t *testing.T) {
 	if len(value) != len(defaultValue) {
 		t.Errorf("Different lengths got = %d, want = %d", len(value), len(defaultValue))


### PR DESCRIPTION
This trivial PR enforces the ";" as separator in the topic configuration parameter because with the current regex, any other special character (i.e. ? or $ or % ...) could be used as separator and being accepted.