### PR TITLE
Added Sarama admin client recreation on EOF connection error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,10 +56,10 @@ func main() {
 		glog.Fatalf("Error creating new Sarama client: %v", err)
 	}
 
-	topicService := services.NewTopicService(canaryConfig, client)
+	topicService := services.NewTopicService(canaryConfig, client.Config())
 	producerService := services.NewProducerService(canaryConfig, client)
 	consumerService := services.NewConsumerService(canaryConfig, client)
-	connectionService := services.NewConnectionService(canaryConfig, client)
+	connectionService := services.NewConnectionService(canaryConfig, client.Config())
 
 	canaryManager := workers.NewCanaryManager(canaryConfig, topicService, producerService, consumerService, connectionService)
 	canaryManager.Start()

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -29,7 +29,7 @@ type TopicReconcileResult struct {
 // TopicService defines the service for canary topic management
 type TopicService struct {
 	canaryConfig *config.CanaryConfig
-	client       sarama.Client
+	saramaConfig *sarama.Config
 	admin        sarama.ClusterAdmin
 	initialized  bool
 }
@@ -74,15 +74,12 @@ func (e *ErrExpectedClusterSize) Error() string {
 }
 
 // NewTopicService returns an instance of TopicService
-func NewTopicService(canaryConfig *config.CanaryConfig, client sarama.Client) *TopicService {
-	admin, err := sarama.NewClusterAdminFromClient(client)
-	if err != nil {
-		glog.Fatalf("Error creating the Sarama cluster admin: %v", err)
-	}
+func NewTopicService(canaryConfig *config.CanaryConfig, saramaConfig *sarama.Config) *TopicService {
+	// lazy creation of the Sarama cluster admin client when reconcile for the first time or it's closed
 	ts := TopicService{
 		canaryConfig: canaryConfig,
-		client:       client,
-		admin:        admin,
+		saramaConfig: saramaConfig,
+		admin:        nil,
 	}
 	return &ts
 }
@@ -102,6 +99,17 @@ func NewTopicService(canaryConfig *config.CanaryConfig, client sarama.Client) *T
 // If a scale up, scale down, scale up happens, it forces a leader election for having preferred leaders
 func (ts *TopicService) Reconcile() (TopicReconcileResult, error) {
 	result := TopicReconcileResult{nil, false}
+
+	if ts.admin == nil {
+		glog.Infof("Creating Sarama cluster admin")
+		admin, err := sarama.NewClusterAdmin(ts.canaryConfig.BootstrapServers, ts.saramaConfig)
+		if err != nil {
+			glog.Errorf("Error creating the Sarama cluster admin: %v", err)
+			return result, err
+		}
+		ts.admin = admin
+	}
+
 	// getting brokers for assigning canary topic replicas accordingly
 	// on creation or cluster scale up/down when topic already exists
 	brokers, _, err := ts.admin.DescribeCluster()
@@ -200,6 +208,7 @@ func (ts *TopicService) Close() {
 	if err := ts.admin.Close(); err != nil {
 		glog.Fatalf("Error closing the Sarama cluster admin: %v", err)
 	}
+	ts.admin = nil
 	glog.Infof("Topic service closed")
 }
 

--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -118,12 +118,18 @@ func (cm *CanaryManager) Stop() {
 func (cm *CanaryManager) reconcile() {
 	glog.Infof("Canary manager reconcile ...")
 
-	if result, err := cm.topicService.Reconcile(); err == nil {
+	result, err := cm.topicService.Reconcile()
+	if err == nil {
 		if result.RefreshMetadata {
 			cm.producerService.Refresh()
 		}
 		// producer has to send to partitions assigned to brokers
 		cm.producerService.Send(result.Assignments)
+	} else if err.Error() == "EOF" {
+		// Kafka brokers close connection to the topic service admin client not able to recover
+		// Sarama issues: https://github.com/Shopify/sarama/issues/2042, https://github.com/Shopify/sarama/issues/1796
+		// Workaround closing the topic service with its admin client and the reopen on next reconcile
+		cm.topicService.Close()
 	}
 
 	glog.Infof("... reconcile done")


### PR DESCRIPTION
This PR fixes #94 and #98 closing and recreating the Sarama admin client when an EOF error happens (i.e. Kafka rolling, re-authentication timeout, ...) due to Sarama issue not able to reconnect on its own in this use case.