### PR TITLE
Add script to calculate canary log latencies and quantiles

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,45 @@
+# __Canary Latencies Script__
+
+## Table of Contents
+1. Description
+2. Prerequisites
+3. Usage
+4. Resources
+----
+## __Description__
+
+This is a script to calculate the average producer/consumer/connection latencies from canary logs. This can be useful to determine if the histogram buckets for metrics are set optimally.
+
+It also sorts the information into quantiles and returns them based on the number of cuts specified.
+
+----
+## __Prerequisites__
+
+You must have access to the logs from a canary that's connected to a Kafka cluster (and configured to have the "VERBOSITY_LOG_LEVEL" turned up to "1"), either stored in files or available to be streamed in.
+
+----
+## __Usage__
+
+The basic usage of the script: 
+
+`python canary_latencies.py -f <your-file(s)>`
+
+If you would like to use it with input from STDIN, remove the `-f` flag: 
+
+`cat <your-file> | python canary_latencies.py`
+
+### _Changing Defaults_
++ #### _Number of Cuts_
+By default, the number of cuts in the [quantile method](https://docs.python.org/3/library/statistics.html#statistics.quantiles) is set to `4`. To change this, run the script with the following flag:
+
+`python canary_latencies.py -c <your-number-of-cuts>`
+
++ #### _Quantile Method_
+The quantile method being used is `exclusive` by default. To change this, run the script with the following flag:
+
+`python canary_latencies.py -m inclusive`
+
+----
+## __Resources__
+
++ [_Python Statistics Library_](https://docs.python.org/3/library/statistics.html)

--- a/tools/canary_latencies.py
+++ b/tools/canary_latencies.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+#
+# Copyright Strimzi authors.
+# License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+#
+
+import re
+import argparse
+import fileinput
+import statistics
+
+def parse_logs(files):
+    producer_latencies = []
+    e2e_latencies = []
+    connection_latencies = []
+
+    producer_pattern = re.compile(".*?producer.go:\d+\]\sMessage\ssent.*duration=([0-9]+)\sms")
+    e2e_pattern = re.compile(".*?consumer.go:\d+\]\sMessage\sreceived.*duration=([0-9]+)\sms")
+    connection_pattern = re.compile(".*?connection_check.go:\d+\].*broker\s[0-9]\sin\s([0-9]+)\sms")
+
+    for line in fileinput.input(files):
+            if match := producer_pattern.match(line):
+                producer_latencies.append(int(match.group(1)))
+            elif match := e2e_pattern.match(line):
+                e2e_latencies.append(int(match.group(1)))
+            elif match := connection_pattern.match(line):
+                connection_latencies.append(int(match.group(1)))
+
+    return producer_latencies, e2e_latencies, connection_latencies
+
+def calculate_quantiles(latencies, quantileMethod, numberOfCuts):
+    quantiles = statistics.quantiles(latencies, n=numberOfCuts, method=quantileMethod)
+    return [round(p, 1) for p in quantiles]
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--files', nargs='+', default=[], help='log files (if empty, expects logs to be piped through stdin)')
+    parser.add_argument('-m', '--method', default='exclusive', choices=['exclusive', 'inclusive'], metavar='exclusive', help='change quantile method from exclusive to inclusive')
+    parser.add_argument('-c', '--cuts', default=4, type=int, metavar='4', help='number of cuts in quantile method')
+    args = parser.parse_args()
+
+    producer_latencies, e2e_latencies, connection_latencies = parse_logs(args.files)
+
+    print("\nProducer Latency Average: ")
+    print(round(statistics.mean(producer_latencies), 1))
+
+    print("\nE2E Latency Average: ")
+    print(round(statistics.mean(e2e_latencies), 1))
+
+    print("\nConnection Latency Average: ")
+    print(round(statistics.mean(connection_latencies),1 ))
+
+    quantile_method = args.method
+    number_of_cuts = args.cuts
+
+    print("\nProducer Quantiles: ")
+    print(calculate_quantiles(producer_latencies, quantile_method, number_of_cuts))
+
+    print("\nE2E Quantiles: ")
+    print(calculate_quantiles(e2e_latencies, quantile_method, number_of_cuts))
+
+    print("\nConnection Quantiles: ")
+    print(calculate_quantiles(connection_latencies, quantile_method, number_of_cuts))


### PR DESCRIPTION
This script gathers the latency values from the canary logs and calculates the average producer/consumer/connection latencies. This may be useful to determine if the histogram buckets for metrics are set optimally.
It takes input from one or more files and also accepts input (as lines) from STDIN. 
It also sorts the information into quantiles. When calculating quantiles, the quantile method and number of cuts are both configurable. If left unspecified, it will use the defaults for these. 
For reference: 
https://docs.python.org/3/library/statistics.html#statistics.quantiles