### PR TITLE
Refactor build pipeline

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -10,11 +10,11 @@ pr:
     - '*'
 
 stages:
-- stage: go_build
-  displayName: Go tests and build
+- stage: go_test
+  displayName: Go Test
   jobs:
-  - job: go_tests_and_build
-    displayName: Test & Build
+  - job: go_test
+    displayName: Go Test
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -26,24 +26,26 @@ stages:
       inputs:
         command: test
         arguments: ./internal/... --tags=unit_test
-    - bash: "make go_build"
-      displayName: Go Build
-    - publish: $(Build.SourcesDirectory)/cmd/target
-      displayName: Publish binary
-      artifact: Binary
-- stage: go_e2e_test
-  displayName: Go e2e tests
+    - task: Go@0
+      displayName: Go e2e Tests
+      inputs:
+        command: test
+        arguments: ./test/... --tags=e2e
+- stage: go_build
+  displayName: Go Build
+  dependsOn:
+  - go_test
   jobs:
-  - job: go_e2e_tests
-    displayName: Go e2e tests
+  - job: go_build
+    displayName: Go Build
     pool:
       vmImage: 'ubuntu-latest'
     steps:
     - task: GoTool@0
       inputs:
         version: '1.16.3'
-    - task: Go@0
-      displayName: Go e2e Tests
-      inputs:
-        command: test
-        arguments: ./test/... --tags=e2e
+    - bash: "make go_build"
+      displayName: Go Build
+    - publish: $(Build.SourcesDirectory)/cmd/target
+      displayName: Publish binary
+      artifact: Binary


### PR DESCRIPTION
This PR refactors the build pipeline in order to looks like similar to a Java one with:

* a stage to run unit tests and build/publish binary
* a stage to run e2e tests

It also uses the Go task to run go commands for tests.