### PR TITLE
Added logging application version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ DOCKER_REPO ?= canary
 
 BINARY ?= strimzi-canary
 
+RELEASE_VERSION ?= latest
+
 go_build:
 	echo "Building Golang binary ..."
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cmd/target/$(BINARY) cmd/main.go
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.version=${RELEASE_VERSION}'" -a -installsuffix cgo -o cmd/target/$(BINARY) cmd/main.go
 
 docker_build:
 	echo "Building Docker image ..."

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,8 @@ import (
 )
 
 var (
+	version = "development"
+
 	clientCreationFailed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "client_creation_error_total",
 		Namespace: "strimzi_canary",
@@ -43,7 +45,7 @@ func main() {
 	flag.Set("v", strconv.Itoa(canaryConfig.VerbosityLogLevel))
 	flag.Parse()
 
-	glog.Infof("Starting Strimzi canary tool with config: %+v", canaryConfig)
+	glog.Infof("Starting Strimzi canary tool [%s] with config: %+v", version, canaryConfig)
 
 	statusService := services.NewStatusServiceService(canaryConfig)
 	httpServer := servers.NewHttpServer(statusService)


### PR DESCRIPTION
This PR adds versioning on the tool.
It logs the version at the beginning and env var to set the version at build time.