### PR TITLE
Moved container build job into template

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -56,27 +56,13 @@ stages:
   dependsOn:
   - go_build
   jobs:
-  - job: container_build
-    displayName: Container Build
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-    # step for Docker installation
-    - template: ./templates/steps/setup_docker.yaml
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifact: Binary
-        path: $(Build.SourcesDirectory)/
-    - bash: tar -xvf target.tar
-      displayName: "Untar the target directory"        
-    - bash: .azure/scripts/container-build.sh
-      displayName: Docker Build & Save
-      env:
-        DOCKER_REGISTRY: quay.io
-        DOCKER_ORG: strimzi
-    - publish: $(System.DefaultWorkingDirectory)/canary-container.tar.gz
-      displayName: Publish container
-      artifact: Container
+  - template: ./templates/jobs/container_build.yaml
+    parameters:
+      artifactSource: 'current'
+      artifactProject: 'strimzi'
+      artifactPipeline: ''
+      artifactRunVersion: ''
+      artifactRunId: ''
 - stage:
   displayName: Publish Container
   dependsOn:

--- a/.azure/templates/jobs/container_build.yaml
+++ b/.azure/templates/jobs/container_build.yaml
@@ -1,0 +1,27 @@
+jobs:
+- job: container_build
+  displayName: Container Build
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  # step for Docker installation
+  - template: ../steps/setup_docker.yaml
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: '${{ parameters.artifactSource }}'
+      artifact: Binary
+      path: $(System.DefaultWorkingDirectory)/
+      project: '${{ parameters.artifactProject }}'
+      pipeline: '${{ parameters.artifactPipeline }}'
+      runVersion: '${{ parameters.artifactRunVersion }}'
+      runId: '${{ parameters.artifactRunId }}'
+  - bash: tar -xvf target.tar
+    displayName: "Untar the target directory"        
+  - bash: .azure/scripts/container-build.sh
+    displayName: Docker Build & Save
+    env:
+      DOCKER_REGISTRY: quay.io
+      DOCKER_ORG: strimzi
+  - publish: $(System.DefaultWorkingDirectory)/canary-container.tar.gz
+    displayName: Publish container
+    artifact: Container


### PR DESCRIPTION
This PR moves the container build job into a template to be reused for a future release pipeline.