### PR TITLE
Fixed release version env var in go build script

### DIFF
--- a/.azure/scripts/go-build.sh
+++ b/.azure/scripts/go-build.sh
@@ -4,7 +4,4 @@ set -e
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
-export RELEASE_VERSION=$(cat ./release.version)
-echo "Building for ${RELEASE_VERSION}"
-
 make go_build

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -1,4 +1,5 @@
 BINARY ?= strimzi-canary
+RELEASE_VERSION ?= $(shell cat ./release.version)
 
 .PHONY: go_build
 go_build:


### PR DESCRIPTION
Fixing where the RELEASE_VERSION env var is exported/defined for the go_build target.
Currently during the release target it's overridden by the one defined in the imported Makefile with go_build target.