### PR TITLE
Added supported SASL mechanisms in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ When running the Strimzi canary tool, it is possible to configure different aspe
 * `TLS_CLIENT_CERT`: TLS client certificate, in PEM format, to use for enabling TLS client authentication against the Kafka cluster. Default empty.
 * `TLS_CLIENT_KEY`: TLS client private key, in PEM format, to use for enabling TLS client authentication against the Kafka cluster. Default empty.
 * `TLS_INSECURE_SKIP_VERIFY`:  if the underneath Sarama client has to verify the server's certificate chain and host name. Default `false`.
-* `SASL_MECHANISM`: mechanism to use for SASL authentication against the Kafka cluster. Default empty.
-* `SASL_USER`: username for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Supported is `PLAIN`. Default empty.
-* `SASL_PASSWORD`: password for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty.
+* `SASL_MECHANISM`: mechanism to use for SASL authentication against the Kafka cluster. Supported is `PLAIN`. Default empty.
+* `SASL_USER`: username for SASL authentication against the Kafka cluster when PLAIN is used. Default empty.
+* `SASL_PASSWORD`: password for SASL authentication against the Kafka cluster when PLAIN is used. Default empty.
 * `CONNECTION_CHECK_INTERVAL_MS`: it defines how often the tool has to check the connection with brokers (in ms). Default `120000`.
 * `CONNECTION_CHECK_LATENCY_BUCKETS`: buckets of the histogram related to the brokers connection latency metric (in ms). Default `100,200,400,800,1600`.
 * `STATUS_CHECK_INTERVAL_MS`: it defines how often (in ms) the tool updates internal status information (i.e. percentage of consumed messages) to expose outside on the corresponding HTTP endpoint. Default `30000`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When running the Strimzi canary tool, it is possible to configure different aspe
 * `TLS_CLIENT_KEY`: TLS client private key, in PEM format, to use for enabling TLS client authentication against the Kafka cluster. Default empty.
 * `TLS_INSECURE_SKIP_VERIFY`:  if the underneath Sarama client has to verify the server's certificate chain and host name. Default `false`.
 * `SASL_MECHANISM`: mechanism to use for SASL authentication against the Kafka cluster. Default empty.
-* `SASL_USER`: username for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty.
+* `SASL_USER`: username for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Supported is `PLAIN`. Default empty.
 * `SASL_PASSWORD`: password for SASL authentication against the Kafka cluster when PLAIN or SCRAM-SHA are used. Default empty.
 * `CONNECTION_CHECK_INTERVAL_MS`: it defines how often the tool has to check the connection with brokers (in ms). Default `120000`.
 * `CONNECTION_CHECK_LATENCY_BUCKETS`: buckets of the histogram related to the brokers connection latency metric (in ms). Default `100,200,400,800,1600`.


### PR DESCRIPTION
Adding on the doc that `PLAIN` is the only SASL mechanism supported right now.