### PR TITLE
Fix #133: add synchronizing token to canary messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for SCRAM-SHA-256 and SCRAM-SHA-512 authentication
 * Added Python script tool to calculate latencies and quantiles from canary log for producer, consumer and connection buckets
+* #133: Add synchronizing token to canary messages to detect messages sent by previous invocations of the canary or even previous instances
 
 ## 0.1.0
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Shopify/sarama v1.29.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/hashicorp/go-uuid v1.0.2
 	github.com/prometheus/client_golang v1.8.0
 	github.com/xdg-go/scram v1.0.2
 )

--- a/internal/services/canary_message.go
+++ b/internal/services/canary_message.go
@@ -16,6 +16,7 @@ type CanaryMessage struct {
 	ProducerID string `json:"producerId"`
 	MessageID  int    `json:"messageId"`
 	Timestamp  int64  `json:"timestamp"`
+	Sync       string `json:"sync"`
 }
 
 func NewCanaryMessage(bytes []byte) CanaryMessage {
@@ -30,6 +31,6 @@ func (cm CanaryMessage) Json() string {
 }
 
 func (cm CanaryMessage) String() string {
-	return fmt.Sprintf("{ProducerID:%s, MessageID:%d, Timestamp:%d}",
-		cm.ProducerID, cm.MessageID, cm.Timestamp)
+	return fmt.Sprintf("{ProducerID:%s, MessageID:%d, Timestamp:%d Sync:%s}",
+		cm.ProducerID, cm.MessageID, cm.Timestamp, cm.Sync)
 }

--- a/internal/services/canary_message_test.go
+++ b/internal/services/canary_message_test.go
@@ -19,8 +19,9 @@ func TestCanaryMessage(t *testing.T) {
 		ProducerID: "producer-id",
 		MessageID:  0,
 		Timestamp:  12345,
+		Sync: "sync",
 	}
-	want := "{\"producerId\":\"producer-id\",\"messageId\":0,\"timestamp\":12345}"
+	want := "{\"producerId\":\"producer-id\",\"messageId\":0,\"timestamp\":12345,\"sync\":\"sync\"}"
 	if cm.Json() != want {
 		t.Errorf("JSON got = %s, want = %s", cm.Json(), want)
 	}
@@ -31,6 +32,7 @@ func TestCanaryMessageEncode(t *testing.T) {
 		ProducerID: "producer-id",
 		MessageID:  0,
 		Timestamp:  12345,
+		Sync: "sync",
 	}
 	encoder := sarama.StringEncoder(cm.Json())
 	bytes, _ := encoder.Encode()
@@ -41,7 +43,7 @@ func TestCanaryMessageEncode(t *testing.T) {
 		t.Errorf("got = %v, want = %v", decodedCm, cm)
 	}
 
-	wrong := "{\"producerId\":\"producer-id\",\"messageId\":1,\"timestamp\":67890}"
+	wrong := "{\"producerId\":\"producer-id\",\"messageId\":1,\"timestamp\":67890,\"sync\":\"stale\"}"
 
 	encoder = sarama.StringEncoder(wrong)
 	bytes, _ = encoder.Encode()

--- a/internal/services/synchronizer.go
+++ b/internal/services/synchronizer.go
@@ -1,0 +1,40 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+package services
+
+import (
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-uuid"
+	"sync/atomic"
+)
+
+type Synchronizer struct {
+	sync atomic.Value
+}
+
+func NewSynchronizer() *Synchronizer {
+	var s Synchronizer
+	s.sync.Store(getUuid())
+	return &s
+}
+
+func (s *Synchronizer) Next() (next string) {
+	next = getUuid()
+	s.sync.Store(next)
+	return
+}
+
+func (s *Synchronizer) Current() string {
+	return s.sync.Load().(string)
+}
+
+func getUuid() (value string) {
+	value, err := uuid.GenerateUUID()
+	if err != nil {
+		glog.Fatalf("Unexpected error generating UUID: %v", err)
+	}
+	return
+}

--- a/internal/services/synchronizer_test.go
+++ b/internal/services/synchronizer_test.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestSynchronizer_IsInitialized(t *testing.T) {
+	s := NewSynchronizer()
+	if s.Current() == "" {
+		t.Errorf("Unexpected empty value from new synchronizer")
+	}
+}
+
+func TestSynchronizer_CurrentIdempotent(t *testing.T) {
+	s := NewSynchronizer()
+	current := s.Current()
+	current1 := s.Current()
+	if current != current1 {
+		t.Errorf("Successive calls to Current should yield the same result")
+	}
+}
+
+func TestSynchronizer_Next(t *testing.T) {
+	s := NewSynchronizer()
+	current := s.Current()
+	s.Next()
+	value := s.Current()
+
+	if current == value {
+		t.Errorf("Next expected to produce new value")
+	}
+}


### PR DESCRIPTION
..to detect messages produced by previous connections (or previous invocation) to avoid skewing message latency results.