### PR TITLE
Fix #133: turn off producer retry and add a consumer error metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for SCRAM-SHA-256 and SCRAM-SHA-512 authentication
 * Added Python script tool to calculate latencies and quantiles from canary log for producer, consumer and connection buckets
+* #133: turn off producer retry and add a consumer error metric
 
 ## 0.1.0
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,8 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Producer.Retry.Max = 0
+	config.Consumer.Return.Errors = true
 
 	if canaryConfig.SaramaLogEnabled {
 		sarama.Logger = log.New(os.Stdout, "[Sarama] ", log.LstdFlags)


### PR DESCRIPTION
Signed-off-by: Keith Wall <kwall@apache.org>