### PR TITLE
Fixed wrong Content-Type on the status endpoint

### DIFF
--- a/internal/services/status_check.go
+++ b/internal/services/status_check.go
@@ -105,6 +105,7 @@ func (ss *StatusService) StatusHandler() http.Handler {
 		}
 
 		json, _ := json.Marshal(status)
+		rw.Header().Add("Content-Type", "application/json")
 		rw.Write(json)
 	})
 }


### PR DESCRIPTION
This PR fixes #144 returning the correct "application/json" content type on the `/status` endpoint.