### PR TITLE
Refresh describe brokers when not the expected numbers in connection

### DIFF
--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -122,7 +122,7 @@ func (cs *ConnectionService) connectionCheck() {
 		cs.admin = admin
 	}
 
-	if cs.isDynamicScalingEnabled() || cs.brokers == nil {
+	if cs.isDynamicScalingEnabled() || cs.canaryConfig.ExpectedClusterSize != len(cs.brokers) {
 		cs.brokers, _, err = cs.admin.DescribeCluster()
 		if err != nil {
 			if err.Error() == "EOF" {


### PR DESCRIPTION
This PR fixes #141.
The problem was that the connection service just asked for the cluster topology once and maybe when a Kafka cluster is starting up not all the brokers are ready.
For this reason, the change is about the connection service to refresh the describe cluster until the "expected" number of brokers is reached. This way at the beginning it just tests the already running brokers but at some point it will start testing the last starting ones; from this point in time the topology is not refreshed anymore and if brokers go out and in, it will just checks failed connections increasing the metrics.
Different with dynamic scaling up and down, it will test only the running brokers (part of the topology) so refreshing the topology every time (this behaviour doesn't change from current status).