### PR TITLE
Updated CHANGELOG with Prometheus and Grafana examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+* Added Prometheus support via `PodMonitor` and sample Grafana dashboard for exposed metrics
+
 ## 0.2.0
 
 * Added support for SCRAM-SHA-256 and SCRAM-SHA-512 authentication (#130)


### PR DESCRIPTION
Trivial PR to update the CHANGELOG with info about the Prometheus support via `PodMonitor` and the sample of Grafana dashboard for metrics.