### PR TITLE
Treat ETIMEDOUT (TCP keep-alive failure) as a disconnection conditio too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0
 
 * Added Prometheus support via `PodMonitor` and sample Grafana dashboard for exposed metrics
+* Treat ETIMEDOUT (TCP keep-alive failure) as a disconnection condition too
 
 ## 0.2.0
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,5 +20,5 @@ func NowInMilliseconds() int64 {
 
 // IsDisconnection returns true if the err provided represents a TCP disconnection
 func IsDisconnection(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE)
+	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ETIMEDOUT)
 }


### PR DESCRIPTION
Proposed fix to #159.

Signed-off-by: kwall <kwall@apache.org>