### PR TITLE
treat os.ErrDeadlineExceeded (i/o timeout) as a disconnected condition too

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,6 +9,7 @@ package util
 import (
 	"errors"
 	"io"
+	"os"
 	"syscall"
 	"time"
 )
@@ -20,5 +21,5 @@ func NowInMilliseconds() int64 {
 
 // IsDisconnection returns true if the err provided represents a TCP disconnection
 func IsDisconnection(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ETIMEDOUT)
+	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ETIMEDOUT) || errors.Is(err, os.ErrDeadlineExceeded)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -9,6 +9,7 @@ package util
 import (
 	"errors"
 	"io"
+	"os"
 	"syscall"
 	"testing"
 )
@@ -24,6 +25,7 @@ func TestIsDisconnection(t *testing.T) {
 		{syscall.EPIPE, true},
 		{syscall.ECONNRESET, true},
 		{syscall.ETIMEDOUT, true},
+		{os.ErrDeadlineExceeded, true},
 	}
 
 	for _, tst := range cases {


### PR DESCRIPTION
In the end I decided it was best to treat `os.ErrDeadlineExceeded` (i/o timeout) as a disconnected condition.  I was influenced by sarama's own error handling  [consumer.go:818
](https://github.com/Shopify/sarama/blob/712b6bb89287b4767557cc4bf9883148b4979a85/consumer.go#L806) actually closes the broker on any net conditions (`err != nil`).  Having the canary handle this net condition in the same way seemed least worst.  I took the cautious approach and just added `os.ErrDeadlineExceeded` to the existing list of conditions.
