### PR TITLE
Fix data race issue introduced by #166

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ var (
 	}, nil)
 )
 
+var saramaLogger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
 func main() {
 	// get canary configuration
 	canaryConfig := config.NewCanaryConfig()
@@ -43,6 +44,7 @@ func main() {
 	if err := flag.Set("logtostderr", "true"); err != nil {
 		glog.Errorf("Error on setting logtostderr to true")
 	}
+	sarama.Logger = saramaLogger
 
 	applyDynamicConfig(&canaryConfig.DynamicCanaryConfig)
 
@@ -135,9 +137,9 @@ func applyDynamicConfig(dynamicCanaryConfig *config.DynamicCanaryConfig) {
 	}
 
 	if dynamicCanaryConfig.SaramaLogEnabled != nil && *dynamicCanaryConfig.SaramaLogEnabled {
-		sarama.Logger = log.New(os.Stdout, "[Sarama] ", log.LstdFlags)
+		saramaLogger.SetOutput(os.Stdout)
 	} else {
-		sarama.Logger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
+		saramaLogger.SetOutput(io.Discard)
 	}
 	glog.Warningf("Applied dynamic config %s", dynamicCanaryConfig)
 }

--- a/internal/config/dynamic_config_watcher.go
+++ b/internal/config/dynamic_config_watcher.go
@@ -64,10 +64,9 @@ func NewDynamicConfigWatcher(canaryConfig *CanaryConfig, applyFunc func(config *
 	return dynamicConfigWatcher, nil
 }
 
-func (c DynamicConfigWatcher) Close()  {
+func (c *DynamicConfigWatcher) Close()  {
 	if c.ticker != nil {
 		c.ticker.Stop()
-		c.ticker = nil
 	}
 }
 

--- a/internal/config/dynamic_config_watcher.go
+++ b/internal/config/dynamic_config_watcher.go
@@ -8,17 +8,21 @@ import (
 	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
+	"sync"
 	"time"
 )
 
 type  DynamicConfigWatcher struct {
-	ticker *time.Ticker
 	exists bool
-	hash string
+	hash   string
+	closer sync.Once
+	quit   chan struct{}
 }
 
 func NewDynamicConfigWatcher(canaryConfig *CanaryConfig, applyFunc func(config *DynamicCanaryConfig), defaultFunc func() (*DynamicCanaryConfig)) (*DynamicConfigWatcher, error) {
-	dynamicConfigWatcher := &DynamicConfigWatcher{}
+	dynamicConfigWatcher := &DynamicConfigWatcher{
+		quit: make(chan struct{}),
+	}
 
 	if canaryConfig.DynamicConfigFile != "" && canaryConfig.DynamicConfigWatcherInterval > 0 {
 		glog.Infof("Starting dynamic config watcher for file %s with period %d ms", canaryConfig.DynamicConfigFile, canaryConfig.DynamicConfigWatcherInterval)
@@ -31,12 +35,11 @@ func NewDynamicConfigWatcher(canaryConfig *CanaryConfig, applyFunc func(config *
 			applyFunc(target)
 		}
 
-		dynamicConfigWatcher.ticker = time.NewTicker(canaryConfig.DynamicConfigWatcherInterval * time.Millisecond)
-		quit := make(chan struct{})
 		go func() {
+			ticker := time.NewTicker(canaryConfig.DynamicConfigWatcherInterval * time.Millisecond)
 			for {
 				select {
-				case <- dynamicConfigWatcher.ticker.C:
+				case <- ticker.C:
 					if _, err := os.Stat(canaryConfig.DynamicConfigFile); err == nil {
 						dynamicConfigWatcher.exists = true
 						target, hsh, err := readAndHash(canaryConfig.DynamicConfigFile)
@@ -53,8 +56,8 @@ func NewDynamicConfigWatcher(canaryConfig *CanaryConfig, applyFunc func(config *
 						dynamicConfigWatcher.exists = false
 						applyFunc(defaultFunc())
 					}
-				case <- quit:
-					dynamicConfigWatcher.ticker.Stop()
+				case <- dynamicConfigWatcher.quit:
+					ticker.Stop()
 					return
 				}
 			}
@@ -65,9 +68,9 @@ func NewDynamicConfigWatcher(canaryConfig *CanaryConfig, applyFunc func(config *
 }
 
 func (c *DynamicConfigWatcher) Close()  {
-	if c.ticker != nil {
-		c.ticker.Stop()
-	}
+	c.closer.Do(func() {
+		close(c.quit)
+	})
 }
 
 func readAndHash(filename string) (target *DynamicCanaryConfig, h string, err error) {


### PR DESCRIPTION
I didn't notice yesterday that I'd introduced a data-race (reported by `go test --race ./...`) in #166.  Sorry about that.

This first change addresses that.   One of the data races was caused by the use of a value receiver for the #Close() function., which I found really subtle (http://tleyden.github.io/blog/2016/05/19/go-race-detector-gotcha-with-value-receivers/ helped me understand).

The second change addresses thread-safety concerns around the manipulation of sarama.Logger from different go routines without being protected by mutex.  This wasn't reported by `go test --race`.  However I think my proposed change is much easier to reason about in terms of correctness.

The final change ensures that the goroutine beneath the watcher actually ends, rather than being left around.