### PR TITLE
Updated default Kafka version used by Sarama to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added Prometheus support via `PodMonitor` and sample Grafana dashboard for exposed metrics
 * Treat ETIMEDOUT (TCP keep-alive failure) as a disconnection condition too (#159)
 * Updated dependency to Sarama 1.33.0 (#176)
+* Updated default Kafka version used by Sarama library to 3.1.0
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The configuration file described in more detail the next section.
 | `PRODUCER_LATENCY_BUCKETS` | Buckets of the histogram related to the producer latency metric (in ms). | `100,200,400,800,1600` |  |
 | `ENDTOEND_LATENCY_BUCKETS` | Buckets of the histogram related to the end to end latency metric between producer and consumer (in ms). | `100,200,400,800,1600` |  |
 | `EXPECTED_CLUSTER_SIZE` | Expected number of brokers in the Kafka cluster where the canary connects to. This parameter avoids that the tool runs more partitions reassignment of the topic while the Kafka cluster is starting up and the brokers are coming one by one. `-1` means "dynamic" reassignment as described above. When greater than 0, the canary waits for the Kafka cluster having the expected number of brokers running before creating the topic and assigning the partitions | `-1` |  |
-| `KAFKA_VERSION` | Version of the Kafka cluster | `2.8.0` |  |
+| `KAFKA_VERSION` | Version of the Kafka cluster | `3.1.0` |  |
 | `SARAMA_LOG_ENABLED` | Enables the Sarama client logging. | `false` | `saramaLogEnabled` |
 | `VERBOSITY_LOG_LEVEL` | Verbosity of the tool logging. Allowed values 0 = INFO, 1 = DEBUG, 2 = TRACE | `0` | `verbosityLogLevel` |
 | `TLS_ENABLED` | If the canary has to use TLS to connect to the Kafka cluster. | `false` |  |

--- a/internal/config/canary_config.go
+++ b/internal/config/canary_config.go
@@ -60,7 +60,7 @@ const (
 	ProducerLatencyBucketsDefault        = "100,200,400,800,1600"
 	EndToEndLatencyBucketsDefault        = "100,200,400,800,1600"
 	ExpectedClusterSizeDefault           = -1 // "dynamic" reassignment is enabled
-	KafkaVersionDefault                  = "2.8.0"
+	KafkaVersionDefault                  = "3.1.0"
 	SaramaLogEnabledDefault              = false
 	VerbosityLogLevelDefault             = 0 // default 0 = INFO, 1 = DEBUG, 2 = TRACE
 	TLSEnabledDefault                    = false
@@ -80,8 +80,8 @@ const (
 )
 
 type DynamicCanaryConfig struct {
-	SaramaLogEnabled              *bool `json:"saramaLogEnabled"`
-	VerbosityLogLevel             *int  `json:"verbosityLogLevel"`
+	SaramaLogEnabled  *bool `json:"saramaLogEnabled"`
+	VerbosityLogLevel *int  `json:"verbosityLogLevel"`
 }
 
 // CanaryConfig defines the canary tool configuration
@@ -126,7 +126,7 @@ func NewDynamicCanaryConfig() *DynamicCanaryConfig {
 }
 
 func (c DynamicCanaryConfig) String() string {
-	commaPad := func (str string) string {
+	commaPad := func(str string) string {
 		if len(str) > 0 {
 			str = str + ", "
 		}
@@ -272,7 +272,7 @@ func (c CanaryConfig) String() string {
 	return fmt.Sprintf("{BootstrapServers:%s, BootstrapBackoffMaxAttempts:%d, BootstrapBackoffScale:%d, Topic:%s, TopicConfig:%v, ReconcileInterval:%d ms, "+
 		"ClientID:%s, ConsumerGroupID:%s, ProducerLatencyBuckets:%v, EndToEndLatencyBuckets:%v, ExpectedClusterSize:%d, KafkaVersion:%s,"+
 		"TLSEnabled:%t, TLSCACert:%s, TLSClientCert:%s, TLSClientKey:%s, TLSInsecureSkipVerify:%t,"+
-		"SASLMechanism:%s, SASLUser:%s, SASLPassword:%s, ConnectionCheckInterval:%d ms, ConnectionCheckLatencyBuckets:%v, StatusCheckInterval:%d ms, StatusTimeWindow:%d ms," +
+		"SASLMechanism:%s, SASLUser:%s, SASLPassword:%s, ConnectionCheckInterval:%d ms, ConnectionCheckLatencyBuckets:%v, StatusCheckInterval:%d ms, StatusTimeWindow:%d ms,"+
 		"DynamicConfigFile: %s, DynamicCanaryConfig: %s, DynamicConfigWatcherInterval: %d ms}",
 		c.BootstrapServers, c.BootstrapBackoffMaxAttempts, c.BootstrapBackoffScale, c.Topic, c.TopicConfig, c.ReconcileInterval, c.ClientID, c.ConsumerGroupID,
 		c.ProducerLatencyBuckets, c.EndToEndLatencyBuckets, c.ExpectedClusterSize, c.KafkaVersion,


### PR DESCRIPTION
Trivial PR to update the default Kafka version used by Sarama library to the latest supported 3.1.0