### PR TITLE
Added clarification on not enough samples in status time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ The `Consuming` field provides information about the `Percentage` of messages co
 }
 ```
 
+If there are not enough messages produced and consumed over the configured time window, the `/status` endpoint will report a `Percentage: -1` and the canary will log `Error processing consumed records percentage: No data samples available in the time window ring`.
+
 ## Metrics
 
 In order to check how your Apache Kafka cluster is behaving, the Canary provides the following metrics on the corresponding HTTP endpoint.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `Consuming` field provides information about the `Percentage` of messages co
 }
 ```
 
-If there are not enough messages produced and consumed over the configured time window, the `/status` endpoint will report a `Percentage: -1` and the canary will log `Error processing consumed records percentage: No data samples available in the time window ring`.
+If the time window has not ended, the `/status` endpoint cannot report a percentage of correctly consumed messages. Instead, it returns `Percentage: -1`. The canary also logs `Error processing consumed records percentage: No data samples available in the time window ring`.  In this case, you wait until the time window has ended for the sampling to complete. 
 
 ## Metrics
 


### PR DESCRIPTION
Trivial PR to clarify the `Percentage` when there are not enough messages produced/consumed over the time window.