### PR TITLE
Fixed consumer fetch max wait time due to Sarama potential bug

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ var (
 )
 
 var saramaLogger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
+
 func main() {
 	// get canary configuration
 	canaryConfig := config.NewCanaryConfig()
@@ -98,7 +99,9 @@ func newClient(canaryConfig *config.CanaryConfig) (sarama.Client, error) {
 	config.Producer.RequiredAcks = sarama.WaitForAll
 	config.Producer.Retry.Max = 0
 	config.Consumer.Return.Errors = true
-
+	// this Sarama fix https://github.com/Shopify/sarama/pull/2227 increases the canary e2e latency
+	// it shows a potential bug in Sarama. We revert the value back here while waiting for a Sarama fix
+	config.Consumer.MaxWaitTime = 250 * time.Millisecond
 
 	if canaryConfig.TLSEnabled {
 		config.Net.TLS.Enable = true


### PR DESCRIPTION
While testing RC2, we found that the end to end latency on the canary was increased.
After some investigation (thanks to @k-wall) it turned out that the following change in Sarama is the root cause: https://github.com/Shopify/sarama/pull/2227
It highlights that there could be a potential bug elsewhere in Sarama which has to be addressed.
Meanwhile, the canary can be updated by setting that consumer max time to the same 250 ms (as before in Sarama).