### PR TITLE
include milliseconds is sarama debug log timestamp

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ var (
 	}, nil)
 )
 
-var saramaLogger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
+var saramaLogger = log.New(io.Discard, "[Sarama] ", log.Ldate | log.Lmicroseconds)
 
 func main() {
 	// get canary configuration


### PR DESCRIPTION
Sarama debug logging is made more useful by including the milliseconds portion in the timestamps. With this change the output looks like:

```
[Sarama] 2022/06/08 19:13:47.953676 client/brokers registered new broker #0 at broker-0-penguin-cagbmplvo-vi--h--aog.kas.kwall-kafka.3zz3.s1.devshift.org:443
[Sarama] 2022/06/08 19:13:47.953693 Successfully initialized new client
```
