### PR TITLE
fix: #188 use separate sarama clients for producer and consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0
 
 * Fixed replicas assignment taking rack configuration into account (#190)
+* Use separate sarama clients for producer/consumer in order to reliably measure message latency (#188)
 
 ## 0.3.0
 


### PR DESCRIPTION
Sharing a client meant that the client's await for FetchResponse could skew the latency measurement.  This change means that the producer and consumer services create their own clients.  This will increase the number of connections consumed by the canary on the kafka cluster (by 33%).

Signed-off-by: Keith Wall <kwall@apache.org>