### PR TITLE
Updated CHANGELOG with OpenTelemetry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.5.0
+
+* Added support for OpenTelemetry (#197)
+  * Only "jaeger" and "otlp" are supported as exporter protocols for tracing. See documentation for more details.
+
 ## 0.4.0
 
 * Fixed replicas assignment taking rack configuration into account (#190)


### PR DESCRIPTION
This trivial PR adds the latest OpenTelemetry addition (#197) to the CHANGELOG.