### PR TITLE
fixed missing containerport in deployment

### DIFF
--- a/install/020-Deployment.yaml
+++ b/install/020-Deployment.yaml
@@ -44,5 +44,9 @@ spec:
           requests:
             memory: "64Mi"
             cpu: "100m"
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
   strategy:
     type: Recreate

--- a/packaging/install/020-Deployment.yaml
+++ b/packaging/install/020-Deployment.yaml
@@ -47,5 +47,9 @@ spec:
           requests:
             memory: "64Mi"
             cpu: "100m"
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
   strategy:
     type: Recreate


### PR DESCRIPTION
containerport was missing in the deployment. This prevented prometheus from scraping the port correctly.