### PR TITLE
Remove duplicated ports from packaging deployment files

### DIFF
--- a/packaging/install/020-Deployment.yaml
+++ b/packaging/install/020-Deployment.yaml
@@ -18,9 +18,6 @@ spec:
       containers:
       - name: strimzi-canary
         image: quay.io/strimzi/canary:latest
-        ports:
-        - containerPort: 8080
-          name: metrics
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092


### PR DESCRIPTION
This PR removes duplicated `ports` from packaging deployment examples.