### PR TITLE
Fix #204: Have the consuming client refresh its metadata if the partition leadership changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,25 +133,26 @@ If the time window has not ended, the `/status` endpoint cannot report a percent
 
 In order to check how your Apache Kafka cluster is behaving, the Canary provides the following metrics on the corresponding HTTP endpoint.
 
-| Name | Description |
-| ---- | ----------- |
-| `client_creation_error_total` | Total number of errors while creating Sarama client |
-| `expected_cluster_size_error_total` | Total number of errors while waiting the Kafka cluster having the expected size |
-| `topic_creation_failed_total` | Total number of errors while creating the canary topic |
-| `topic_describe_cluster_error_total` | Total number of errors while describing cluster |
-| `topic_describe_error_total` | Total number of errors while getting canary topic metadata |
-| `topic_alter_assignments_error_total` | Total number of errors while altering partitions assignments for the canary topic |
-| `topic_alter_configuration_error_total` | Total number of errors while altering configuration for the canary topic |
-| `records_produced_total` | The total number of records produced |
-| `records_produced_failed_total` | The total number of records failed to produce |
-| `producer_refresh_metadata_error_total` | Total number of errors while refreshing producer metadata |
-| `records_produced_latency` | Records produced latency in milliseconds |
-| `records_consumed_total` | The total number of records consumed |
-| `consumer_error_total` | Total number of errors reported by the consumer |
-| `consumer_timeout_join_group_total` | The total number of consumers not joining the group within the timeout |
-| `records_consumed_latency` | Records end-to-end latency in milliseconds |
-| `connection_error_total`| Total number of errors while checking the connection to Kafka brokers |
-| `connection_latency` | Latency in milliseconds for established or failed connections |
+| Name                                    | Description                                                                       |
+|-----------------------------------------|-----------------------------------------------------------------------------------|
+| `client_creation_error_total`           | Total number of errors while creating Sarama client                               |
+| `expected_cluster_size_error_total`     | Total number of errors while waiting the Kafka cluster having the expected size   |
+| `topic_creation_failed_total`           | Total number of errors while creating the canary topic                            |
+| `topic_describe_cluster_error_total`    | Total number of errors while describing cluster                                   |
+| `topic_describe_error_total`            | Total number of errors while getting canary topic metadata                        |
+| `topic_alter_assignments_error_total`   | Total number of errors while altering partitions assignments for the canary topic |
+| `topic_alter_configuration_error_total` | Total number of errors while altering configuration for the canary topic          |
+| `records_produced_total`                | The total number of records produced                                              |
+| `records_produced_failed_total`         | The total number of records failed to produce                                     |
+| `producer_refresh_metadata_error_total` | Total number of errors while refreshing producer metadata                         |
+| `records_produced_latency`              | Records produced latency in milliseconds                                          |
+| `records_consumed_total`                | The total number of records consumed                                              |
+| `consumer_error_total`                  | Total number of errors reported by the consumer                                   |
+| `consumer_timeout_join_group_total`     | The total number of consumers not joining the group within the timeout            |
+| `consumer_refresh_metadata_error_total` | Total number of errors while refreshing consumer metadata                         |
+| `records_consumed_latency`              | Records end-to-end latency in milliseconds                                        |
+| `connection_error_total`                | Total number of errors while checking the connection to Kafka brokers             |
+| `connection_latency`                    | Latency in milliseconds for established or failed connections                     |
 
 Following an example of metrics output.
 

--- a/internal/services/producer.go
+++ b/internal/services/producer.go
@@ -40,7 +40,7 @@ var (
 	// it's defined when the service is created because buckets are configurable
 	recordsProducedLatency *prometheus.HistogramVec
 
-	refreshMetadataError = promauto.NewCounterVec(prometheus.CounterOpts{
+	refreshProducerMetadataError = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "producer_refresh_metadata_error_total",
 		Namespace: "strimzi_canary",
 		Help:      "Total number of errors while refreshing producer metadata",
@@ -124,7 +124,7 @@ func (ps *producerService) Refresh() {
 		labels := prometheus.Labels{
 			"clientid": ps.canaryConfig.ClientID,
 		}
-		refreshMetadataError.With(labels).Inc()
+		refreshProducerMetadataError.With(labels).Inc()
 		glog.Errorf("Error refreshing metadata in producer: %v", err)
 	}
 }

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -163,6 +163,7 @@ func (ts *topicService) reconcileTopic() (TopicReconcileResult, error) {
 			}
 			glog.Infof("The canary topic %s was created", topicMetadata.Name)
 
+			// now the topic is created, describe it, so we have the leader information to return to the caller later.
 			topicMetadata, err = ts.describeCanaryTopic()
 			if err != nil {
 				return result, err


### PR DESCRIPTION
This minimises the time the canary spends consuming from followers after the partition leadership changes on the cluster. This avoid the end to end latency measure being skewed by the additional latency introduced by the highwatermark propagation between leader/followers.  I left a fuller explanation on this comment: https://github.com/strimzi/strimzi-canary/issues/204#issuecomment-1326695982

