### PR TITLE
Refactoring allow for the writing of a canary_manager unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
+	github.com/stretchr/testify v1.8.1
 	github.com/xdg-go/scram v1.1.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.32.0
 	go.opentelemetry.io/otel v1.7.0
@@ -40,6 +41,7 @@ require (
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
@@ -56,4 +58,5 @@ require (
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -216,9 +216,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -264,6 +266,7 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -274,8 +277,9 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -283,8 +287,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
@@ -617,6 +622,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/internal/config/canary_config_test.go
+++ b/internal/config/canary_config_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package config defining the canary configuration parameters
 package config

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package security defining some security related tools
 package security

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package security defining some security related tools
 package security

--- a/internal/servers/http_server.go
+++ b/internal/servers/http_server.go
@@ -22,7 +22,7 @@ type HttpServer struct {
 }
 
 // NewHttpServer returns an instance of the HttpServer
-func NewHttpServer(statusService *services.StatusService) *HttpServer {
+func NewHttpServer(statusService services.StatusService) *HttpServer {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/liveness", services.LivenessHandler())

--- a/internal/services/backoff_test.go
+++ b/internal/services/backoff_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package services defines an interface for canary services and related implementations
 package services

--- a/internal/services/canary_message_test.go
+++ b/internal/services/canary_message_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package services defines an interface for canary services and related implementations
 package services

--- a/internal/services/topic_test.go
+++ b/internal/services/topic_test.go
@@ -22,17 +22,17 @@ import (
 
 func TestRequestedAssignments(t *testing.T) {
 	var tests = []struct {
-		name                string
-		numPartitions       int
-		numBrokers          int
-		useRack             bool
+		name                       string
+		numPartitions              int
+		numBrokers                 int
+		useRack                    bool
 		brokersWithMultipleLeaders []int32
-		expectedMinISR      int
+		expectedMinISR             int
 	}{
 		{"one broker", 1, 1, false, []int32{}, 1},
 		{"three brokers without rack info", 3, 3, false, []int32{}, 2},
 		{"fewer brokers than partitions", 3, 2, false, []int32{0}, 1},
-		{"six brokers with rack info",  6, 6, true, []int32{}, 2},
+		{"six brokers with rack info", 6, 6, true, []int32{}, 2},
 	}
 
 	for _, tt := range tests {
@@ -43,7 +43,7 @@ func TestRequestedAssignments(t *testing.T) {
 
 			brokers, brokerMap := createBrokers(t, tt.numBrokers, tt.useRack)
 
-			ts := NewTopicService(cfg, nil)
+			ts := NewTopicService(cfg, nil).(*topicService)
 
 			assignments, minISR := ts.requestedAssignments(tt.numPartitions, brokers)
 
@@ -84,7 +84,7 @@ func TestRequestedAssignments(t *testing.T) {
 			for brokerId, count := range leaderBrokers {
 				if count > 1 {
 					found := false
-					for _, expectedBrokerId  := range tt.brokersWithMultipleLeaders {
+					for _, expectedBrokerId := range tt.brokersWithMultipleLeaders {
 						if expectedBrokerId == brokerId {
 							found = true
 							break
@@ -126,7 +126,7 @@ func TestRequestedAssignments(t *testing.T) {
 func createBrokers(t *testing.T, num int, rack bool) ([]*sarama.Broker, map[int32]*sarama.Broker) {
 	brokers := make([]*sarama.Broker, 0)
 	brokerMap := make(map[int32]*sarama.Broker)
-	for i := 0; i < num ; i++ {
+	for i := 0; i < num; i++ {
 		broker := &sarama.Broker{}
 
 		setBrokerID(t, broker, i)

--- a/internal/services/topic_test.go
+++ b/internal/services/topic_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build unit_test
+//go:build unit_test
 
 // Package services defines an interface for canary services and related implementations
 

--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -20,11 +20,11 @@ import (
 // CanaryManager defines the manager driving the different producer, consumer and topic services
 type CanaryManager struct {
 	canaryConfig      *config.CanaryConfig
-	topicService      *services.TopicService
-	producerService   *services.ProducerService
-	consumerService   *services.ConsumerService
-	connectionService *services.ConnectionService
-	statusService     *services.StatusService
+	topicService      services.TopicService
+	producerService   services.ProducerService
+	consumerService   services.ConsumerService
+	connectionService services.ConnectionService
+	statusService     services.StatusService
 	stop              chan struct{}
 	syncStop          sync.WaitGroup
 }
@@ -39,9 +39,9 @@ var (
 
 // NewCanaryManager returns an instance of the cananry manager worker
 func NewCanaryManager(canaryConfig *config.CanaryConfig,
-	topicService *services.TopicService, producerService *services.ProducerService,
-	consumerService *services.ConsumerService, connectionService *services.ConnectionService,
-	statusService *services.StatusService) Worker {
+	topicService services.TopicService, producerService services.ProducerService,
+	consumerService services.ConsumerService, connectionService services.ConnectionService,
+	statusService services.StatusService) Worker {
 	cm := CanaryManager{
 		canaryConfig:      canaryConfig,
 		topicService:      topicService,

--- a/internal/workers/canary_manager_test.go
+++ b/internal/workers/canary_manager_test.go
@@ -1,0 +1,152 @@
+//
+// Copyright Strimzi authors.
+// License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+//
+
+//go:build unit_test
+
+package workers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/strimzi/strimzi-canary/internal/config"
+	"github.com/strimzi/strimzi-canary/internal/services"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type mockTopicService struct {
+	refresh atomic.Bool
+	leaders map[int32]int32
+}
+
+func newMockTopicService() *mockTopicService {
+	return &mockTopicService{}
+}
+
+func (ts *mockTopicService) Reconcile() (services.TopicReconcileResult, error) {
+	refreshed := ts.refresh.CompareAndSwap(true, false)
+	return services.TopicReconcileResult{
+		RefreshMetadata: refreshed,
+	}, nil
+}
+
+func (ts *mockTopicService) flagReconcile() {
+	ts.refresh.Store(true)
+}
+
+func (ts *mockTopicService) resetLeaders(leaders map[int32]int32) {
+	ts.leaders = leaders
+
+}
+
+func (ts *mockTopicService) Close() {
+}
+
+type mockProducerService struct {
+	refreshCounter uint32
+}
+
+func newMockProducerService() *mockProducerService {
+	return &mockProducerService{}
+}
+
+func (m *mockProducerService) Send(_ map[int32][]int32) {
+}
+
+func (m *mockProducerService) Refresh() {
+	atomic.AddUint32(&m.refreshCounter, 1)
+}
+
+func (m *mockProducerService) getRefreshCount() uint32 {
+	return atomic.LoadUint32(&m.refreshCounter)
+}
+
+func (m mockProducerService) Close() {
+}
+
+type mockConsumerService struct {
+	refreshCounter uint32
+	leaders        map[int32]int32
+}
+
+func newMockConsumerService() *mockConsumerService {
+	return &mockConsumerService{
+		leaders: map[int32]int32{},
+	}
+}
+
+func (m *mockConsumerService) Consume() {
+}
+
+func (m *mockConsumerService) Refresh() {
+}
+
+func (m *mockConsumerService) Close() {
+}
+
+func (m *mockConsumerService) Leaders() (map[int32]int32, error) {
+	return m.leaders, nil
+}
+
+func (m *mockConsumerService) getRefreshCount() uint32 {
+	return atomic.LoadUint32(&m.refreshCounter)
+}
+
+func (m *mockConsumerService) setLeaders(leaders map[int32]int32) {
+	m.leaders = leaders
+}
+
+type mockConnectionService struct{}
+
+func newMockConnectionService() *mockConnectionService {
+	return &mockConnectionService{}
+}
+
+func (m mockConnectionService) Open() {
+}
+
+func (m mockConnectionService) Close() {
+}
+
+type mockStatusService struct{}
+
+func (m mockStatusService) Open() {
+}
+
+func (m mockStatusService) Close() {
+}
+
+func (m mockStatusService) StatusHandler() http.Handler {
+	return nil
+}
+
+func newMockStatusService() *mockStatusService {
+	return &mockStatusService{}
+}
+
+func TestPublisherMetadataRefresh(t *testing.T) {
+	cfg := &config.CanaryConfig{
+		ReconcileInterval: 1,
+	}
+	topicService := newMockTopicService()
+	producerService := newMockProducerService()
+	consumerService := newMockConsumerService()
+	connectionService := newMockConnectionService()
+	statusService := newMockStatusService()
+
+	manager := NewCanaryManager(cfg, topicService, producerService, consumerService, connectionService, statusService)
+	manager.Start()
+	defer manager.Stop()
+
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		topicService.flagReconcile()
+	}()
+
+	assert.Eventually(t, func() bool {
+		return producerService.getRefreshCount() == 1
+	}, time.Second*1, time.Millisecond*50, "expecting producer service to be refreshed once")
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3,7 +3,7 @@
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 //
 
-// +build e2e
+//go:build e2e
 
 package test
 


### PR DESCRIPTION
I want to use mocks in #206 to help write tests to support the bug fix.  To use mocks I require the services to have  interfaces. I've introduced these using a mechanical refactorings.   To keep the reviews easy, I kept this as a separate change.

This change has no functional effect.