### PR TITLE
Add OCI label org.opencontainers.image.source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM scratch
 
 ADD cmd/target/strimzi-canary ./
 
+LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-canary'
+
 ENTRYPOINT ["/strimzi-canary"]


### PR DESCRIPTION
Update Dockerfile with the following OCI label `org.opencontainers.image.source` in the docker image to indicate the source repo URL. This would allow to tools like Renovate to update to point to source and add the release notes when updating the strimzi-canary dependency.

Signed-off-by: Fares Oueslati <oueslati.fares@gmail.com>