### PR TITLE
Make the docker binary configurable so that podman can be used

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,3 +1,4 @@
+DOCKER_CMD ?= docker
 DOCKER_REGISTRY ?= docker.io
 DOCKER_ORG ?= $(USER)
 DOCKER_TAG ?= latest
@@ -7,29 +8,29 @@ BUILD_TAG ?= latest
 docker_build:
 	# Build Docker image ...
 	echo "Building Docker image ..."
-	docker build -t strimzi/${PROJECT_NAME}:latest .
+	${DOCKER_CMD} build -t strimzi/${PROJECT_NAME}:latest .
 	# Also tag with $(BUILD_TAG)
-	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+	${DOCKER_CMD} tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
 
 .PHONY: docker_save
 docker_save:
 	# Saves the container as TGZ file
 	echo "Saving Docker image as tar.gz file ..."
-	docker save strimzi/${PROJECT_NAME}:${BUILD_TAG} | gzip > canary-container.tar.gz
+	${DOCKER_CMD} save strimzi/${PROJECT_NAME}:${BUILD_TAG} | gzip > canary-container.tar.gz
 
 .PHONY: docker_load
 docker_load:
 	# Loads the container as TGZ file
 	echo "Loading Docker image from tar.gz file ..."
-	docker load < canary-container.tar.gz 
+	${DOCKER_CMD} load < canary-container.tar.gz 
 
 .PHONY: docker_tag
 docker_tag:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
-	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	${DOCKER_CMD} tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 .PHONY: docker_push
 docker_push: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
 	echo "Pushing Docker image ..."
-	docker push ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DOCKER_TAG}
+	${DOCKER_CMD} push ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DOCKER_TAG}

--- a/development-docs/DEVELOPING.md
+++ b/development-docs/DEVELOPING.md
@@ -29,7 +29,8 @@ make docker_build docker_push
 
 It is possible to customize the container image build by using the following environment variables:
 
+* `DOCKER_CMD` : the Docker binary to use for all container commands (default is `docker`).
 * `DOCKER_REGISTRY`: the Docker registry where the image will be pushed (default is `docker.io`).
-* `DOCKER_ORG`: the Docker organization for tagging/pushing the image (defaults to the value of the $USER environment variable).
+* `DOCKER_ORG`: the Docker organization for tagging/pushing the image (defaults to the value of the `$USER` environment variable).
 * `DOCKER_TAG`: the Docker tag (default is `latest`).
 * `DOCKER_REPO`: the Docker repository where the image will be pushed (default is `canary`).


### PR DESCRIPTION
This PR make the docker binary configurable in the Makefile.docker so that `podman` can be used instead. The default is set to `docker` so no changes are needed to continue using the current behaviour.