### PR TITLE
Add option to set constant labels for all Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The configuration file described in more detail the next section.
 | `DYNAMIC_CONFIG_FILE` | Location of an optional external config file that provides configuration at runtime. | empty |  |
 | `DYNAMIC_CONFIG_WATCHER_INTERVAL` | Interval that dynamic config file is examined for changes in content (in ms)  | `30000` |  |
 | `EXPORTER_TYPE_TRACING` | Tracing Exporter use. Empty value disable tracing, other possible values are `jaeger` or `otlp`  | `` |  |
-
+| `PROMETHEUS_CONSTANT_LABELS` | A list of semicolon separated `key=value` pairs (i.e. `my-label-1=one;my-label-2=two`) that will be set as constant labels on all prometheus metrics. | empty |  |
 
 ## Dynamic Configuration file
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,5 @@
-//
 // Copyright Strimzi authors.
 // License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
-//
 package main
 
 import (
@@ -44,7 +42,8 @@ var (
 		Help:      "Total number of errors while creating Sarama client",
 	}, nil)
 )
-var saramaLogger = log.New(io.Discard, "[Sarama] ", log.Ldate | log.Lmicroseconds)
+var saramaLogger = log.New(io.Discard, "[Sarama] ", log.Ldate|log.Lmicroseconds)
+
 func initTracerProvider(exporterType string) *sdktrace.TracerProvider {
 	if exporterType == "" {
 		tp := trace.NewNoopTracerProvider()
@@ -81,7 +80,6 @@ func exporterTracing(exporterType string) sdktrace.SpanExporter {
 	}
 	return exporter
 }
-
 
 func main() {
 
@@ -138,6 +136,7 @@ func main() {
 	connectionService := services.NewConnectionService(canaryConfig, saramaConfig)
 
 	canaryManager := workers.NewCanaryManager(canaryConfig, topicService, producerService, consumerService, connectionService, statusService)
+	canaryManager.RegisterMetrics()
 	canaryManager.Start()
 
 	sig := <-signals

--- a/internal/services/topic_test.go
+++ b/internal/services/topic_test.go
@@ -35,15 +35,15 @@ func TestRequestedAssignments(t *testing.T) {
 		{"six brokers with rack info", 6, 6, true, []int32{}, 2},
 	}
 
+	cfg := &config.CanaryConfig{
+		Topic: "test",
+	}
+	ts := NewTopicService(cfg, nil).(*topicService)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.CanaryConfig{
-				Topic: "test",
-			}
 
 			brokers, brokerMap := createBrokers(t, tt.numBrokers, tt.useRack)
-
-			ts := NewTopicService(cfg, nil).(*topicService)
 
 			assignments, minISR := ts.requestedAssignments(tt.numPartitions, brokers)
 

--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -31,11 +31,7 @@ type CanaryManager struct {
 }
 
 var (
-	expectedClusterSizeError = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:      "expected_cluster_size_error_total",
-		Namespace: "strimzi_canary",
-		Help:      "Total number of errors while waiting the Kafka cluster having the expected size",
-	}, nil)
+	expectedClusterSizeError *prometheus.CounterVec
 )
 
 // NewCanaryManager returns an instance of the cananry manager worker
@@ -43,6 +39,7 @@ func NewCanaryManager(canaryConfig *config.CanaryConfig,
 	topicService services.TopicService, producerService services.ProducerService,
 	consumerService services.ConsumerService, connectionService services.ConnectionService,
 	statusService services.StatusService) Worker {
+
 	cm := CanaryManager{
 		canaryConfig:      canaryConfig,
 		topicService:      topicService,
@@ -52,6 +49,15 @@ func NewCanaryManager(canaryConfig *config.CanaryConfig,
 		statusService:     statusService,
 	}
 	return &cm
+}
+
+func (cm *CanaryManager) RegisterMetrics() {
+	expectedClusterSizeError = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "expected_cluster_size_error_total",
+		Namespace:   "strimzi_canary",
+		Help:        "Total number of errors while waiting the Kafka cluster having the expected size",
+		ConstLabels: cm.canaryConfig.PrometheusConstantLabels,
+	}, nil)
 }
 
 // Start runs a first reconcile and start a timer for periodic reconciling

--- a/internal/workers/worker.go
+++ b/internal/workers/worker.go
@@ -10,4 +10,8 @@ package workers
 type Worker interface {
 	Start()
 	Stop()
+	// Register metrics with prometheus default registery.
+	// Decoupling metrics registration from Worker creation allows for multiple workers
+	// to be created for testing without multiple registrations of the same metrics.
+	RegisterMetrics()
 }


### PR DESCRIPTION
This PR adds the option to set constant labels to all Prometheus metrics produced by the canary. These are defined via a semi-colon separated list of key=value pairs, passed in as an enVar.

This PR also includes an attempt to make some of the e2e tests less flaky.