### PR TITLE
error-related count metrics initialized with 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Upgraded to Sarama v1.38.1
 * Upgraded to Prometheus Go Client v1.14.0
 * Upgraded to OpenTelemetry v0.13.0
+* Fixed error-related metrics starting from 0 (#215)
 
 ## 0.6.0
 

--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -159,12 +159,10 @@ func (cs *connectionService) connectionCheck() {
 			"brokerid":  strconv.Itoa(int(b.ID())),
 			"connected": strconv.FormatBool(connected),
 		}
-		// initialize all error-related metrics with starting value of 0
-		if connected {
-			connectionError.With(labels).Add(0)
-		}
+
 		if connected {
 			b.Close()
+			connectionError.With(labels).Add(0)
 			glog.V(1).Infof("Connected to broker %d in %d ms", b.ID(), duration)
 		} else {
 			connectionError.With(labels).Inc()

--- a/internal/services/connection_check.go
+++ b/internal/services/connection_check.go
@@ -36,7 +36,6 @@ type connectionService struct {
 	brokers      []*sarama.Broker
 	stop         chan struct{}
 	syncStop     sync.WaitGroup
-	initialized  bool
 }
 
 // NewConnectionService returns an instance of ConnectionService
@@ -62,7 +61,6 @@ func NewConnectionService(canaryConfig *config.CanaryConfig, saramaConfig *saram
 		canaryConfig: canaryConfig,
 		saramaConfig: saramaConfig,
 		admin:        nil,
-		initialized:  false,
 	}
 	return &cs
 }
@@ -162,7 +160,7 @@ func (cs *connectionService) connectionCheck() {
 			"connected": strconv.FormatBool(connected),
 		}
 		// initialize all error-related metrics with starting value of 0
-		if !cs.initialized {
+		if connected {
 			connectionError.With(labels).Add(0)
 		}
 		if connected {
@@ -174,7 +172,6 @@ func (cs *connectionService) connectionCheck() {
 		}
 		connectionLatency.With(labels).Observe(float64(duration))
 	}
-	cs.initialized = true
 }
 
 // If the "dynamic" scaling is enabled

--- a/internal/services/consumer.go
+++ b/internal/services/consumer.go
@@ -112,11 +112,14 @@ func NewConsumerService(canaryConfig *config.CanaryConfig, client sarama.Client)
 		ready:         make(chan bool),
 	}
 
-	go func() {
-		labels := prometheus.Labels{
-			"clientid": canaryConfig.ClientID,
-		}
+	labels := prometheus.Labels{
+		"clientid": canaryConfig.ClientID,
+	}
+	// initialize all error-related metrics with starting value of 0
+	recordsConsumerFailed.With(labels).Add(0)
+	refreshConsumerMetadataError.With(labels).Add(0)
 
+	go func() {
 		for err := range consumerGroup.Errors() {
 			glog.Errorf("Error received whilst consuming from topic: %v", err)
 			recordsConsumerFailed.With(labels).Inc()

--- a/internal/services/producer.go
+++ b/internal/services/producer.go
@@ -100,7 +100,6 @@ func NewProducerService(canaryConfig *config.CanaryConfig, client sarama.Client)
 // Send sends one message to partitions assigned to brokers
 func (ps *producerService) Send(partitionsAssignments map[int32][]int32) {
 	numPartitions := len(partitionsAssignments)
-
 	msg := &sarama.ProducerMessage{
 		Topic: ps.canaryConfig.Topic,
 	}
@@ -117,7 +116,6 @@ func (ps *producerService) Send(partitionsAssignments map[int32][]int32) {
 			"clientid":  ps.canaryConfig.ClientID,
 			"partition": strconv.Itoa(i),
 		}
-
 		recordsProduced.With(labels).Inc()
 		RecordsProducedCounter++
 		if err != nil {

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -158,6 +158,19 @@ func (ts *topicService) reconcileTopic() (TopicReconcileResult, error) {
 		return result, err
 	}
 
+	// initialize all error-related metrics with starting value of 0
+	if !ts.initialized {
+		labels := prometheus.Labels{
+			"topic": topicMetadata.Name,
+		}
+
+		topicCreationFailed.With(labels).Add(0)
+		describeClusterError.With(nil).Add(0)
+		describeTopicError.With(labels).Add(0)
+		alterTopicAssignmentsError.With(labels).Add(0)
+		alterTopicConfigurationError.With(labels).Add(0)
+	}
+
 	if errors.Is(topicMetadata.Err, sarama.ErrUnknownTopicOrPartition) {
 
 		// canary topic doesn't exist, going to create it

--- a/internal/workers/canary_manager.go
+++ b/internal/workers/canary_manager.go
@@ -58,6 +58,9 @@ func (cm *CanaryManager) RegisterMetrics() {
 		Help:        "Total number of errors while waiting the Kafka cluster having the expected size",
 		ConstLabels: cm.canaryConfig.PrometheusConstantLabels,
 	}, nil)
+
+	// initialize all error-related metrics with starting value of 0
+	expectedClusterSizeError.With(nil).Add(0)
 }
 
 // Start runs a first reconcile and start a timer for periodic reconciling


### PR DESCRIPTION
Issue: https://github.com/strimzi/strimzi-canary/issues/215

All error-related count metrics except "client_creation_error_total" are initialized with value of 0 to prevent PromQL recognizing first exported metric with error to be initial value.
This way, we can define such prometheus alert rule: `increase(strimzi_canary_topic_alter_configuration_error_total[5m]) > 0`
